### PR TITLE
Correct GitHub repo link in app description

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.0-rc.3"
+APP_VERSION = "2.0.0-rc.4"
 
 
 def load_database_config(

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -13,7 +13,7 @@ Job Guests, Show Hosts, Recording Locations, Panelists, Scorekeepers, and
 Shows.
 
 Source code for this application is available on
-[GitHub](https://github.com/questionlp/api.wwdt.me_fastapi).
+[GitHub](https://github.com/questionlp/api.wwdt.me_v2).
     """,
     "contact_info": {
         "name": "Linh Pham",


### PR DESCRIPTION
With the repository name changed from `api.wwdt.me_fastapi` to `api.wwdt.me_v2`, the link in the description for the app metadata needed to be updated