### PR TITLE
Bump version requirements for fastapi, uvicorn, jinja2 and wwdtm

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -101,7 +101,7 @@ options avaiable, check out the [Gunicorn documentation site](https://docs.gunic
 
 ## Setting up a Gunicorn systemd Service
 
-A template `systemd` service file is included in the repository named 
+A template `systemd` service file is included in the repository named
 `gunicorn-wwdtmapi.service.dist`. That service file provides the commands and
 arguments used to start a Gunicorn instance to serve up the application. A copy
 of that template file can be modified and installed under `/etc/systemd/system`.

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.0"
+APP_VERSION = "2.0.1"
 
 
 def load_database_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,12 @@ pycodestyle>=2.8.0
 pytest==6.2.5
 black==22.1.0
 
-fastapi==0.73.0
-uvicorn[standard]==0.17.4
+fastapi==0.75.1
+uvicorn[standard]==0.17.6
 gunicorn==20.1.0
 aiofiles==0.8.0
-jinja2==3.0.3
+jinja2==3.1.1
 email-validator==1.1.3
 requests==2.27.1
 
-wwdtm>=2.0.2
+wwdtm==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-fastapi==0.73.0
-uvicorn[standard]==0.17.4
+fastapi==0.75.1
+uvicorn[standard]==0.17.6
 gunicorn==20.1.0
 aiofiles==0.8.0
-jinja2==3.0.3
+jinja2==3.1.1
 email-validator==1.1.3
 requests==2.27.1
 
-wwdtm>=2.0.2
+wwdtm==2.0.5


### PR DESCRIPTION
Bump package versions for fastapi to 0.75.1, uvicorn to 0.17.6, jinja2 to 3.1.1, and wwdtm to 2.0.5