### PR TITLE
Bumping dependency versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig File
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{json,md,py,rst}]
+charset = utf-8
+
+[*.{css,html,json,py,rst,tmpl}]
+indent_size = 4
+indent_style = space

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.1"
+APP_VERSION = "2.0.2"
 
 
 def load_database_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-required-version = "22.1.0"
+required-version = "22.3.0"
 target-version = ["py36", "py37", "py38", "py39"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
 flake8>=4.0.1
 pycodestyle>=2.8.0
-pytest==6.2.5
-black==22.1.0
+pytest==7.1.2
+black==22.3.0
 
-fastapi==0.75.1
+fastapi==0.78.0
 uvicorn[standard]==0.17.6
 gunicorn==20.1.0
 aiofiles==0.8.0
-jinja2==3.1.1
-email-validator==1.1.3
+jinja2==3.1.2
+email-validator==1.2.1
 requests==2.27.1
 
 wwdtm==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-fastapi==0.75.1
+fastapi==0.78.0
 uvicorn[standard]==0.17.6
 gunicorn==20.1.0
 aiofiles==0.8.0
-jinja2==3.1.1
-email-validator==1.1.3
+jinja2==3.1.2
+email-validator==1.2.1
 requests==2.27.1
 
 wwdtm==2.0.5


### PR DESCRIPTION
Bump dependency versions for FastAPI, Jinja2 and email-validator:

- Bump FastAPI from 0.75.1 to 0.78.0
- Bump Jinja2 from 3.1.1 to 3.1.2
- Bump email-validator from 1.1.3 to 1.2.1

For development environments:
- Bump pytest from 6.2.5 to 7.1.2
- Bump black from 22.1.0 to 22.3.0