### PR TITLE
Update fastapi, uvicorn and jinja2 component versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Component Changes
 
 - Upgrade fastapi from 0.78.0 to 0.79.0
-- Upgrade unicorn from 0.17.6 to 0.18.2
+- Upgrade uvicorn from 0.17.6 to 0.18.2
 
 ### Development Changes
 


### PR DESCRIPTION
# Component Changes

- Upgrade fastapi from 0.78.0 to 0.79.0
- Upgrade uvicorn from 0.17.6 to 0.18.2

### Development Changes

- Upgrade black from 22.3.0 to 22.6.0
- Change Black `target-version` to remove `py36` and `py37`, and add `py310`