### PR TITLE
Upgrade fastapi, uvicorn and black required versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Component Changes
 
 - Upgrade fastapi from 0.78.0 to 0.79.0
-- Upgrade unicorn from 0.17.6 to 0.18.2
+- Upgrade uvicorn from 0.17.6 to 0.18.2
 
 ### Development Changes
 

--- a/README.md
+++ b/README.md
@@ -2,62 +2,37 @@
 
 ## Overview
 
-The Stats API is written in Python and is built on
-[FastAPI](https://fastapi.tiangolo.com/) and provides endpoints that can be
-used to query guest, host, location, panelist, scorekeeper, and show data from
-a copy of the
-[Wait Wait Don't Tell Me! Stats database](https://github.com/questionlp/wwdtm_database).
+The Stats API is written in Python and is built on [FastAPI](https://fastapi.tiangolo.com/) and provides endpoints that can be used to query guest, host, location, panelist, scorekeeper, and show data from a copy of the [Wait Wait Don't Tell Me! Stats database](https://github.com/questionlp/wwdtm_database).
 
-If you're looking for the version 1.0 of the API, check out the
-[api.wwdt.me](https://github.com/questionlp/api.wwdt.me) repository.
+If you're looking for the version 1.0 of the API, check out the [api.wwdt.me](https://github.com/questionlp/api.wwdt.me) repository.
 
 ## Requirements
 
 - Python 3.8 or newer
-- MySQL or MariaDB Server hosting a version of the aforementioned Wait Wait
-Don't Tell Me! Stats database
+- MySQL or MariaDB Server hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Changes from v1.0
 
-Stats API v2.0 not only brings a significant change on web frameworks,
-migrating from [Flask](https://flask.palletsprojects.com/) to FastAPI, but
-also breaks compatibility with v1.0 and in terms of API documentation.
+Stats API v2.0 not only brings a significant change on web frameworks, migrating from [Flask](https://flask.palletsprojects.com/) to FastAPI, but also breaks compatibility with v1.0 and in terms of API documentation.
 
-For additional details on the breaking changes that the new version brings,
-refer to the [API-CHANGES.md](API-CHANGES.md) document. The document details
-the new API response object format, changes in API endpoints, and migrating
-to OpenAPI-based documentation.
+For additional details on the breaking changes that the new version brings, refer to the [API-CHANGES.md](API-CHANGES.md) document. The document details the new API response object format, changes in API endpoints, and migrating to OpenAPI-based documentation.
 
 ## Known Issues
 
 ### OpenAPI 3.0 Specification and Response Models
 
-The application makes significant use of `Optional`, `Union`, and `Tuple`
-types in the properties for the various response models. This is a necessity
-due to the way objects are built and returned from
-[wwdtm](https://github.com/questionlp/wwdtm). Unfortunately, OpenAPI 3.0,
-the version of the specification that FastAPI supports, does not provide
-analogs for those types in its specification.
+The application makes significant use of `Optional`, `Union`, and `Tuple` types in the properties for the various response models. This is a necessity due to the way objects are built and returned from [wwdtm](https://github.com/questionlp/wwdtm). Unfortunately, OpenAPI 3.0, the version of the specification that FastAPI supports, does not provide analogs for those types in its specification.
 
-This issue doesn't come up when querying the API through Swagger UI or directly
-using Postman; but, if you've imported the generated OpenAPI JSON into Postman,
-then run queries and/or tests, it will result in warnings and/or errors being
-reported about type mismatches (i.e.: returns `null` instead of a string).
+This issue doesn't come up when querying the API through Swagger UI or directly using Postman; but, if you've imported the generated OpenAPI JSON into Postman, then run queries and/or tests, it will result in warnings and/or errors being reported about type mismatches (i.e.: returns `null` instead of a string).
 
 ## Installation
 
-Refer to [INSTALLING.md](INSTALLING.md) for information on how to set up an
-instance of this web application that can be served through
-[Gunicorn](https://gunicorn.org) and [NGINX](https://nginx.org/).
+Refer to [INSTALLING.md](INSTALLING.md) for information on how to set up an instance of this web application that can be served through [Gunicorn](https://gunicorn.org) and [NGINX](https://nginx.org/).
 
 ## Code of Conduct
 
-This projects follows version 2.1 of the
-[Contributor Convenant's](https://www.contributor-covenant.org/) Code of
-Conduct. A copy of the [Code of Conduct](CODE_OF_CONDUCT.md) document is
-included in this repository.
+This projects follows version 2.1 of the [Contributor Convenant's](https://www.contributor-covenant.org/) Code of Conduct. A copy of the [Code of Conduct](CODE_OF_CONDUCT.md) document is included in this repository.
 
 ## License
 
-This web application is licensed under the terms of the
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+This web application is licensed under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-required-version = "22.3.0"
-target-version = ["py36", "py37", "py38", "py39"]
+required-version = "22.6.0"
+target-version = ["py38", "py39", "py310"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-flake8>=4.0.1
-pycodestyle>=2.8.0
+flake8==4.0.1
+pycodestyle==2.8.0
 pytest==7.1.2
 black==22.3.0
 
-fastapi==0.78.0
-uvicorn[standard]==0.17.6
+fastapi==0.79.0
+uvicorn[standard]==0.18.2
 gunicorn==20.1.0
 aiofiles==0.8.0
 jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi==0.78.0
-uvicorn[standard]==0.17.6
+fastapi==0.79.0
+uvicorn[standard]==0.18.2
 gunicorn==20.1.0
 aiofiles==0.8.0
 jinja2==3.1.2


### PR DESCRIPTION
## Component Changes

- Upgrade fastapi from 0.78.0 to 0.79.0
- Upgrade uvicorn from 0.17.6 to 0.18.2

## Development Changes

- Upgrade black from 22.3.0 to 22.6.0
- Change Black `target-version` to remove `py36` and `py37`, and add `py310`