### PR TITLE
Update Dependencies and Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.0.4
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.5 to 2.0.7, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
+  - Upgrade NumPy from 1.22.3 to 1.23.2
+  - Upgrade pytz from 2022.1 to 2022.2.1
+- Upgrade requests from 2.27.1 to 2.28.1
+
+### Development Changes
+
+- Correct required version of Black from 22.3.0 to 22.6.0 in `requirements-dev.txt`
+
 ## 2.0.3
 
 ### Component Changes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you're looking for the version 1.0 of the API, check out the [api.wwdt.me](ht
 ## Requirements
 
 - Python 3.8 or newer
-- MySQL or MariaDB Server hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
+- MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Changes from v1.0
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.3"
+APP_VERSION = "2.0.4"
 
 
 def load_database_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8==4.0.1
 pycodestyle==2.8.0
 pytest==7.1.2
-black==22.3.0
+black==22.6.0
 
 fastapi==0.79.0
 uvicorn[standard]==0.18.2
@@ -9,6 +9,6 @@ gunicorn==20.1.0
 aiofiles==0.8.0
 jinja2==3.1.2
 email-validator==1.2.1
-requests==2.27.1
+requests==2.28.1
 
-wwdtm==2.0.5
+wwdtm==2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ gunicorn==20.1.0
 aiofiles==0.8.0
 jinja2==3.1.2
 email-validator==1.2.1
-requests==2.27.1
+requests==2.28.1
 
-wwdtm==2.0.5
+wwdtm==2.0.7


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.0.5 to 2.0.7, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.28 to 8.0.30
  - Upgrade NumPy from 1.22.3 to 1.23.2
  - Upgrade pytz from 2022.1 to 2022.2.1
- Upgrade requests from 2.27.1 to 2.28.1

## Development Changes

- Correct required version of Black from 22.3.0 to 22.6.0 in `requirements-dev.txt`