### PR TITLE
Add Messaging regarding deprecating API v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.0.5
+
+### Application Changes
+
+- Officially deprecate Stats API v1.0 and add a notice on the main index page. No other application changes were made.
+
 ## 2.0.4
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.4"
+APP_VERSION = "2.0.5"
 
 
 def load_database_config(

--- a/static/style.css
+++ b/static/style.css
@@ -4,7 +4,6 @@
  * Copyright (c) 2018-2022 Linh Pham
  * api.wwdt.me is relased under the terms of the Apache License 2.0
  */
-
 @media all {
     html {
         font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -20,6 +19,12 @@
         margin: 2em 0;
     }
 
+    div.notice {
+        border: 1px red solid;
+        font-size: 1.1rem;
+        padding: 1rem 1.5rem;
+    }
+
     div.page-link {
         font-size: 1.75rem;
         margin: 1em 1em;
@@ -28,12 +33,17 @@
     .links,
     .links:link,
     .links:active,
-    .links:visited {
+    .links:visited,
+    div.notice a,
+    div.notice a:link,
+    div.notice a:active,
+    div.notice a:visited {
         text-decoration: none;
         border-bottom: dotted;
     }
 
-    .links:hover {
+    .links:hover,
+    div.notice a:hover {
         text-decoration: none;
         border-bottom: solid;
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,18 @@
     </header>
 
     <main>
+        <div class="notice">
+            <p>
+                <b>Note:</b> API v1.0 has been deprecated and will no longer
+                be available for use after January 31, 2023.
+            </p>
+            <p>
+                Please migrate your application from using API v1.0 to v2.0.
+                For more information on the changes from v1.0 to v2.0, refer
+                to <a href="https://github.com/questionlp/api.wwdt.me_v2/blob/main/API-CHANGES.md">API-CHANGES.md</a>
+                in the GitHub repository.
+            </p>
+        </div>
         <div class="page-link">
             <a class="links" href="/v1.0/docs">API v1.0 Documentation →</a>
         </div>


### PR DESCRIPTION
## Application Changes

- Officially deprecate Stats API v1.0 and add a notice on the main index page. No other application changes were made.