### PR TITLE
Upgrade Components and Fix Media Type Returned for robots.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.6
 
+### Application Changes
+
+- Explicitly return `text/plain` as the media type for `/robots.txt`
+
 ### Component Changes
 
 - Upgrade fastapi from 0.79.0 to 0.85.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 2.0.6
+
+### Component Changes
+
+- Upgrade fastapi from 0.79.0 to 0.85.0
+- Upgrade uvicorn from 0.18.2 to 0.18.3
+- Upgrade aiofiles from 0.8.0 to 22.1.0
+
+### Development Changes
+
+- Upgrade pytest from 7.1.2 to 7.1.3
+
 ## 2.0.5
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.0.5"
+APP_VERSION = "2.0.6"
 
 
 def load_database_config(

--- a/app/main.py
+++ b/app/main.py
@@ -59,17 +59,17 @@ async def favicon():
     return RedirectResponse("/static/favicon.ico", status_code=301)
 
 
-@app.get("/robots.txt", include_in_schema=False, response_class=FileResponse)
-@app.head("/robots.txt", include_in_schema=False, response_class=FileResponse)
+@app.get("/robots.txt", include_in_schema=False)
+@app.head("/robots.txt", include_in_schema=False)
 async def robots_txt():
     """Attempts to serve up static/robots.txt or
     static/robots.txt.dist to the requester. Raise a 404 error if
     neither file are found.
     """
     if exists("static/robots.txt"):
-        return "static/robots.txt"
+        return FileResponse(path="static/robots.txt", media_type="text/plain")
     elif exists("static/robots.txt.dist"):
-        return "static/robots.txt.dist"
+        return FileResponse(path="static/robots.txt.dist", media_type="text/plain")
     else:
         raise HTTPException(status_code=404)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 flake8==4.0.1
 pycodestyle==2.8.0
-pytest==7.1.2
+pytest==7.1.3
 black==22.6.0
 
-fastapi==0.79.0
-uvicorn[standard]==0.18.2
+fastapi==0.85.0
+uvicorn[standard]==0.18.3
 gunicorn==20.1.0
-aiofiles==0.8.0
+aiofiles==22.1.0
 jinja2==3.1.2
 email-validator==1.2.1
 requests==2.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.79.0
-uvicorn[standard]==0.18.2
+fastapi==0.85.0
+uvicorn[standard]==0.18.3
 gunicorn==20.1.0
-aiofiles==0.8.0
+aiofiles==22.1.0
 jinja2==3.1.2
 email-validator==1.2.1
 requests==2.28.1


### PR DESCRIPTION
## Application Changes

- Explicitly return `text/plain` as the media type for `/robots.txt`

## Component Changes

- Upgrade fastapi from 0.79.0 to 0.85.0
- Upgrade uvicorn from 0.18.2 to 0.18.3
- Upgrade aiofiles from 0.8.0 to 22.1.0

## Development Changes

- Upgrade pytest from 7.1.2 to 7.1.3