### PR TITLE
Adding settings config section and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 - Upgrade aiofiles from 0.8.0 to 22.1.0
 - Upgrade email-validator from 1.2.1 to 1.3.0
 
+### Development Changes
+
+- Upgrade flake8 from 4.0.1 to 5.0.4
+- Upgrade pycodestyle from 2.8.0 to 2.9.1
+- Upgrade pytest from 7.1.2 to 7.2.0
+- Upgrade black from 22.6.0 to 22.10.0
+
 ## 2.0.6
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changes
 
+## 2.1.0
+
+### Application Changes
+
+- Added `settings` section to the application `config.json` and `config.json.dist` template file with the following keys:
+  - `stats_url` to set the URL for the Wait Wait Stats Page
+  - `contact_email` to set a contact e-mail address for the OpenAPI metadata
+  - `contact_name` to set a contact name for the OpenAPI metadata
+  - `contact_url` to set a contact URL for the OpenAPI metadata
+- Renamed `load_database_config` in `app.config` to `load_config` that returns a dictionary with `database` and `settings` as keys containing the corresponding values as a dictionary from `config.json`
+- Update all references to `app.config.load_database_config` to `app.config.load_config`
+- Update `app/metadata.py` to make use of the new contact e-mail, name and URL configuration keys
+- Update the `index.html` template to make use of the `stats_url` configuration key
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.7 to 2.0.8, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
+  - Upgrade NumPy from 1.23.2 to 1.23.4
+  - Upgrade python-slugify from 5.0.2 to 6.1.2
+  - Upgrade pytz from 2022.2.1 to 2022.6
+- Upgrade fastapi from 0.85.0 to 0.88.0
+  - Add httpx 0.23.1 as a requirement for fastapi 0.88.0
+- Upgrade uvicorn from 0.18.3 to 0.20.0
+- Upgrade aiofiles from 0.8.0 to 22.1.0
+- Upgrade email-validator from 1.2.1 to 1.3.0
+
 ## 2.0.6
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -61,9 +61,6 @@ def load_config(
             if "use_pool" in database_config:
                 del database_config["use_pool"]
 
-        return {
-            "database": database_config,
-            "settings": settings_config
-        }
+        return {"database": database_config, "settings": settings_config}
     else:
         return {}

--- a/app/main.py
+++ b/app/main.py
@@ -56,7 +56,9 @@ async def default_page(request: Request):
         stats_url = settings.get("stats_url", None)
     else:
         stats_url = None
-    return templates.TemplateResponse("index.html", {"request": request, "stats_url": stats_url})
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "stats_url": stats_url}
+    )
 
 
 @app.get("/favicon.ico", include_in_schema=False, response_class=RedirectResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.config import API_VERSION, APP_VERSION
+from app.config import API_VERSION, APP_VERSION, load_config
 from app.metadata import app_metadata, tags_metadata
 from app.routers import (
     guests,
@@ -44,13 +44,19 @@ app = FastAPI(
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
+config = load_config()
 
 
 # region Generic Routes
 @app.get("/", include_in_schema=False, response_class=HTMLResponse)
 @app.head("/", include_in_schema=False, response_class=HTMLResponse)
 async def default_page(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    if "settings" in config and config["settings"]:
+        settings = config["settings"]
+        stats_url = settings.get("stats_url", None)
+    else:
+        stats_url = None
+    return templates.TemplateResponse("index.html", {"request": request, "stats_url": stats_url})
 
 
 @app.get("/favicon.ico", include_in_schema=False, response_class=RedirectResponse)

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -5,6 +5,16 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """FastAPI Metdata for api.wwdt.me"""
 
+from app.config import load_config
+
+
+_config = load_config()
+if "settings" in _config and _config["settings"]:
+    _settings = _config["settings"]
+    contact_email = _settings.get("contact_email", "")
+    contact_name = _settings.get("contact_name", "")
+    contact_url = _settings.get("contact_url", "")
+
 app_metadata = {
     "title": "Wait Wait Don't Tell Me Stats API",
     "description": """
@@ -16,8 +26,9 @@ Source code for this application is available on
 [GitHub](https://github.com/questionlp/api.wwdt.me_v2).
     """,
     "contact_info": {
-        "name": "Linh Pham",
-        "email": "dev@wwdt.me",
+        "email": contact_email,
+        "name": contact_name,
+        "url": contact_url,
     },
     "license_info": {
         "name": "Apache 2.0",

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -5,7 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Not My Job Guests endpoints"""
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -19,7 +19,8 @@ from app.models.guests import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/guests")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -5,7 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Hosts endpoints"""
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -19,7 +19,8 @@ from app.models.hosts import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -5,7 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Locations endpoints"""
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -19,7 +19,8 @@ from app.models.locations import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/locations")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -5,7 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Panelists endpoints"""
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -22,7 +22,8 @@ from app.models.panelists import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/panelists")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -5,7 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Scorekeeper endpoints"""
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -19,7 +19,8 @@ from app.models.scorekeepers import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/scorekeepers")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -7,7 +7,7 @@
 
 from datetime import date
 
-from app.config import API_VERSION, load_database_config
+from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
@@ -22,7 +22,8 @@ from app.models.shows import (
 )
 
 router = APIRouter(prefix=f"/v{API_VERSION}/shows")
-_database_config = load_database_config()
+_config = load_config()
+_database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 

--- a/config.json.dist
+++ b/config.json.dist
@@ -14,5 +14,11 @@
         "charset": "utf8mb4",
         "collation": "utf8mb4_unicode_ci",
         "time_zone": "America/Los_Angeles"
+    },
+    "settings": {
+        "stats_url": "https://stats.wwdt.me/",
+        "contact_email": "",
+        "contact_name": "",
+        "contact_url": ""
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-required-version = "22.6.0"
-target-version = ["py38", "py39", "py310"]
+required-version = "22.10.0"
+target-version = ["py38", "py39", "py310", "py311"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,15 @@
-flake8==4.0.1
-pycodestyle==2.8.0
-pytest==7.1.3
-black==22.6.0
+flake8==5.0.4
+pycodestyle==2.9.1
+pytest==7.2.0
+black==22.10.0
 
-fastapi==0.85.0
-uvicorn[standard]==0.18.3
+fastapi==0.88.0
+uvicorn[standard]==0.20.0
 gunicorn==20.1.0
+httpx==0.23.1
 aiofiles==22.1.0
 jinja2==3.1.2
-email-validator==1.2.1
+email-validator==1.3.0
 requests==2.28.1
 
-wwdtm==2.0.7
+wwdtm==2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-fastapi==0.85.0
-uvicorn[standard]==0.18.3
+fastapi==0.88.0
+uvicorn[standard]==0.20.0
 gunicorn==20.1.0
+httpx==0.23.1
 aiofiles==22.1.0
 jinja2==3.1.2
-email-validator==1.2.1
+email-validator==1.3.0
 requests==2.28.1
 
-wwdtm==2.0.7
+wwdtm==2.0.8

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,11 @@
             <a class="links" href="/v2.0/openapi">Try out API v2.0 →</a>
         </div>
         <div class="page-link">
+            {% if stats_url %}
+            <a class="links" href="{{ stats_url }}">Stats Page →</a>
+            {% else %}
             <a class="links" href="https://stats.wwdt.me/">Stats Page →</a>
+            {% endif %}
         </div>
     </main>
 </body>


### PR DESCRIPTION
## Application Changes

- Added `settings` section to the application `config.json` and `config.json.dist` template file with the following keys:
  - `stats_url` to set the URL for the Wait Wait Stats Page
  - `contact_email` to set a contact e-mail address for the OpenAPI metadata
  - `contact_name` to set a contact name for the OpenAPI metadata
  - `contact_url` to set a contact URL for the OpenAPI metadata
- Renamed `load_database_config` in `app.config` to `load_config` that returns a dictionary with `database` and `settings` as keys containing the corresponding values as a dictionary from `config.json`
- Update all references to `app.config.load_database_config` to `app.config.load_config`
- Update `app/metadata.py` to make use of the new contact e-mail, name and URL configuration keys
- Update the `index.html` template to make use of the `stats_url` configuration key

## Component Changes

- Upgrade wwdtm from 2.0.7 to 2.0.8, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
  - Upgrade NumPy from 1.23.2 to 1.23.4
  - Upgrade python-slugify from 5.0.2 to 6.1.2
  - Upgrade pytz from 2022.2.1 to 2022.6
- Upgrade fastapi from 0.85.0 to 0.88.0
  - Add httpx 0.23.1 as a requirement for fastapi 0.88.0
- Upgrade uvicorn from 0.18.3 to 0.20.0
- Upgrade aiofiles from 0.8.0 to 22.1.0
- Upgrade email-validator from 1.2.1 to 1.3.0

## Development Changes

- Upgrade flake8 from 4.0.1 to 5.0.4
- Upgrade pycodestyle from 2.8.0 to 2.9.1
- Upgrade pytest from 7.1.2 to 7.2.0
- Upgrade black from 22.6.0 to 22.10.0