### PR TITLE
Add input validation to `contact_info` used for OpenAPI metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.1.1
+
+### Application Changes
+
+- Better handling of how `app.metadata.app_metadata` is populated in case the corresponding values are not set in `config.json`
+
 ## 2.1.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Application Changes
 
 - Better handling of how `app.metadata.app_metadata` is populated in case the corresponding values are not set in `config.json`
+- Add validation of `contact_email`, `contact_name` and `contact_url` values when populating `app.metadata.app_metadata`
 
 ## 2.1.0
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.1.0"
+APP_VERSION = "2.1.1"
 
 
 def load_config(

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -3,17 +3,20 @@
 #
 # Copyright (c) 2018-2022 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""FastAPI Metdata for api.wwdt.me"""
+"""FastAPI Metadata for api.wwdt.me"""
 
 from app.config import load_config
 
 
 _config = load_config()
+_contact_info = {}
 if "settings" in _config and _config["settings"]:
     _settings = _config["settings"]
-    contact_email = _settings.get("contact_email", "")
-    contact_name = _settings.get("contact_name", "")
-    contact_url = _settings.get("contact_url", "")
+    _contact_info = {
+        "email": _settings.get("contact_email", ""),
+        "name": _settings.get("contact_name", ""),
+        "url": _settings.get("contact_url", ""),
+    }
 
 app_metadata = {
     "title": "Wait Wait Don't Tell Me Stats API",
@@ -25,11 +28,7 @@ Shows.
 Source code for this application is available on
 [GitHub](https://github.com/questionlp/api.wwdt.me_v2).
     """,
-    "contact_info": {
-        "email": contact_email,
-        "name": contact_name,
-        "url": contact_url,
-    },
+    "contact_info": _contact_info,
     "license_info": {
         "name": "Apache 2.0",
         "url": "https://www.apache.org/licenses/LICENSE-2.0.html",

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -6,17 +6,36 @@
 """FastAPI Metadata for api.wwdt.me"""
 
 from app.config import load_config
+from email_validator import validate_email, EmailNotValidError
 
 
 _config = load_config()
 _contact_info = {}
 if "settings" in _config and _config["settings"]:
     _settings = _config["settings"]
-    _contact_info = {
-        "email": _settings.get("contact_email", ""),
-        "name": _settings.get("contact_name", ""),
-        "url": _settings.get("contact_url", ""),
-    }
+    if "contact_name" in _settings and "contact_email" in _settings:
+        try:
+            _name = _settings.get("contact_name")
+            if not _name and not _name.strip():
+                _name: str = "API Developer"
+
+            _email = str(_settings.get("contact_email"))
+            valid_email = validate_email(_email)
+
+            _url = _settings.get("contact_url", None)
+            if not _url or not str(_url).strip():
+                _url = None
+
+            _contact_info = {
+                "name": _name,
+                "email": str(_settings.get("contact_email")),
+                "url": _url,
+            }
+        except EmailNotValidError:
+            _contact_info = {
+                "name": "API Developer",
+                "email": "api@example.org",
+            }
 
 app_metadata = {
     "title": "Wait Wait Don't Tell Me Stats API",


### PR DESCRIPTION
## Application Changes

- Better handling of how `app.metadata.app_metadata` is populated in case the corresponding values are not set in `config.json`
- Add validation of `contact_email`, `contact_name` and `contact_url` values when populating `app.metadata.app_metadata`