### PR TITLE
Prepare for Stats API v1.0 Deprecation and Deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2.1.2
+
+### Application Changes
+
+- Add `/v1.0` and `/v1.0/docs` routes that redirect back to `/` as part of deprecating Stats API v1.0
+- Remove links to Stats API v1.0 docs and update v1.0 deprecation message
+
 ## 2.1.1
 
 ### Application Changes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Stats API is written in Python and is built on [FastAPI](https://fastapi.tiangolo.com/) and provides endpoints that can be used to query guest, host, location, panelist, scorekeeper, and show data from a copy of the [Wait Wait Don't Tell Me! Stats database](https://github.com/questionlp/wwdtm_database).
 
-If you're looking for the version 1.0 of the API, check out the [api.wwdt.me](https://github.com/questionlp/api.wwdt.me) repository.
+Please note that version 1.0 of the Stats API has now been deprecated.
 
 ## Requirements
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """FastAPI application __init__.py for api.wwdt.me"""

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Application Configuration"""
 
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.1.1"
+APP_VERSION = "2.1.2"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """FastAPI main application for api.wwdt.me"""
 
@@ -47,7 +47,6 @@ templates = Jinja2Templates(directory="templates")
 config = load_config()
 
 
-# region Generic Routes
 @app.get("/", include_in_schema=False, response_class=HTMLResponse)
 @app.head("/", include_in_schema=False, response_class=HTMLResponse)
 async def default_page(request: Request):
@@ -104,7 +103,17 @@ async def redoc_redirect_sub():
     return RedirectResponse(f"/v{API_VERSION}/docs", status_code=301)
 
 
-# endregion
+@app.get("/v1.0", include_in_schema=False, response_class=RedirectResponse)
+@app.head("/v1.0", include_in_schema=False, response_class=RedirectResponse)
+async def api_v1_redirect():
+    return RedirectResponse("/", status_code=301)
+
+
+@app.get("/v1.0/docs", include_in_schema=False, response_class=RedirectResponse)
+@app.head("/v1.0/docs", include_in_schema=False, response_class=RedirectResponse)
+async def api_v1_docs_redirect():
+    return RedirectResponse("/", status_code=301)
+
 
 # Add the router modules for Guests, Hosts, Locations, Panelists,
 # Scorekeepers, Shows and Version

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """FastAPI Metadata for api.wwdt.me"""
 

--- a/app/models/guests.py
+++ b/app/models/guests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Guests Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 from pydantic import BaseModel, conint, Field
 
 
-# region Models
 class Guest(BaseModel):
     """Not My Job Guest Information"""
 
@@ -69,6 +68,3 @@ class GuestsDetails(BaseModel):
     """List of Not My Job Guest Details"""
 
     guests: List[GuestDetails] = Field(title="List of Guest Details")
-
-
-# endregion

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Hosts Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 from pydantic import BaseModel, conint, Field
 
 
-# region Host Models
 class Host(BaseModel):
     """Host Information"""
 
@@ -67,6 +66,3 @@ class HostsDetails(BaseModel):
     """List of Host Details"""
 
     hosts: List[HostDetails] = Field(title="List of Host Details")
-
-
-# endregion

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Locations Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional
 from pydantic import BaseModel, conint, Field
 
 
-# region Location Models
 class Location(BaseModel):
     """Location Information"""
 
@@ -67,6 +66,3 @@ class LocationsDetails(BaseModel):
     """List of Location Details"""
 
     locations: List[LocationDetails] = Field(title="List of Location Details")
-
-
-# endregion

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional, Tuple
 from pydantic import BaseModel, conint, Field
 
 
-# region Panelist Models
 class Panelist(BaseModel):
     """Panelist Information"""
 
@@ -217,6 +216,3 @@ class PanelistScoresGroupedOrderedPair(BaseModel):
         "number of times that score "
         "has been earned",
     )
-
-
-# endregion

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Scorekeepers Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 from pydantic import BaseModel, conint, Field
 
 
-# region Scorekeeper Models
 class Scorekeeper(BaseModel):
     """Scorekeeper Information"""
 
@@ -70,6 +69,3 @@ class ScorekeepersDetails(BaseModel):
     """List of Scorekeeper Details"""
 
     scorekeepers: List[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")
-
-
-# endregion

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Models"""
 
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 from pydantic import BaseModel, conint, Field
 
 
-# region Shows Models
 class Show(BaseModel):
     """Show Information"""
 
@@ -133,6 +132,3 @@ class ShowDates(BaseModel):
     """List of Show Dates in ISO format (YYYY-MM-DD)"""
 
     shows: List[str] = Field(title="List of Show Dates")
-
-
-# endregion

--- a/app/models/version.py
+++ b/app/models/version.py
@@ -1,20 +1,16 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """App Version Models"""
 
 from pydantic import BaseModel, Field
 
 
-# region App Version Models
 class Version(BaseModel):
     """Wait Wait Stats API and Application Version Information"""
 
     api: str = Field(title="Wait Wait Stats API Version")
     app: str = Field(title="Application Version")
     wwdtm: str = Field(title="wwdtm Version")
-
-
-# endregion

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """FastAPI application routers __init__.py for api.wwdt.me"""

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Not My Job Guests endpoints"""
 

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Hosts endpoints"""
 
@@ -24,7 +24,6 @@ _database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Information for All Hosts",
@@ -222,6 +221,3 @@ async def get_host_details_by_slug(host_slug: constr(strip_whitespace=True)):
             detail="Database error occurred while trying to "
             "retrieve host information",
         )
-
-
-# endregion

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Locations endpoints"""
 
@@ -24,7 +24,6 @@ _database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Information for All Locations",
@@ -234,6 +233,3 @@ async def get_location_recordings_by_slug(location_slug: constr(strip_whitespace
             detail="Database error occurred while trying to "
             "retrieve location information",
         )
-
-
-# endregion

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Panelists endpoints"""
 
@@ -27,7 +27,6 @@ _database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Information for All Panelists",
@@ -483,6 +482,3 @@ async def get_panelist_scores_ordered_pair_by_slug(
             detail="Database error occurred while trying to "
             "retrieve panelist scores",
         )
-
-
-# endregion

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Scorekeeper endpoints"""
 
@@ -24,7 +24,6 @@ _database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Information for All Scorekeepers",
@@ -239,6 +238,3 @@ async def get_scorekeeper_details_by_slug(
             detail="Database error occurred while trying to "
             "retrieve scorekeeper information",
         )
-
-
-# endregion

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Scorekeeper endpoints"""
 
@@ -27,7 +27,6 @@ _database_config = _config["database"]
 _database_connection = mysql.connector.connect(**_database_config)
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Information for All Shows",
@@ -627,6 +626,3 @@ async def get_shows_recent():
             detail="Database error occurred while retrieving "
             "shows from the database",
         )
-
-
-# endregion

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """API routes for Application Version endpoints"""
 
@@ -13,7 +13,6 @@ from app.models.version import Version
 router = APIRouter(prefix=f"/v{API_VERSION}/version")
 
 
-# region Routes
 @router.get(
     "",
     summary="Retrieve Wait Wait Stats API and Application Version Information",
@@ -29,6 +28,3 @@ async def get_version():
         "app": APP_VERSION,
         "wwdtm": WWDTM_VERSION,
     }
-
-
-# endregion

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
-# api.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2023 Linh Pham
+# api.wwdt.me is released under the terms of the Apache License 2.0
 """pytest conftest.py File"""

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
-# api.wwdt.me is relased under the terms of the Apache License 2.0
+# Copyright (c) 2018-2023 Linh Pham
+# api.wwdt.me is released under the terms of the Apache License 2.0
 """Gunicorn Configuration File"""
 
 # Make a copy of this file and name it `gunicorn.conf.py` in order

--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,7 @@
-/* -*- coding: utf-8 -*-
- * vim: set noai syntax=python ts=4 sw=4:
- *
- * Copyright (c) 2018-2022 Linh Pham
- * api.wwdt.me is relased under the terms of the Apache License 2.0
+/*!
+ * api.wwdt.me (https://github.com/questionlp/api.wwdt.me_v2)
+ * Copyright 2018-2023 Linh Pham
+ * Apache License 2.0 (https://github.com/questionlp/api.wwdt.me_v2/blob/main/LICENSE)
  */
 @media all {
     html {

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,18 +18,13 @@
     <main>
         <div class="notice">
             <p>
-                <b>Note:</b> API v1.0 has been deprecated and will no longer
-                be available for use after January 31, 2023.
+                <b>Note:</b> API v1.0 has been deprecated is no longer available for use.
             </p>
             <p>
-                Please migrate your application from using API v1.0 to v2.0.
-                For more information on the changes from v1.0 to v2.0, refer
-                to <a href="https://github.com/questionlp/api.wwdt.me_v2/blob/main/API-CHANGES.md">API-CHANGES.md</a>
-                in the GitHub repository.
+                For information migrating your application from using API v1.0 to v2.0,
+                refer to the <a href="https://github.com/questionlp/api.wwdt.me_v2/blob/main/API-CHANGES.md">API-CHANGES.md</a>
+                document.
             </p>
-        </div>
-        <div class="page-link">
-            <a class="links" href="/v1.0/docs">API v1.0 Documentation →</a>
         </div>
         <div class="page-link">
             <a class="links" href="/v2.0/docs">API v2.0 Documentation →</a>

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/guests routes
 """

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/hosts routes
 """

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/locations routes
 """

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/panelists routes
 """

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/scorekeepers routes
 """

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/shows routes
 """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Testing /v2.0/version route
 """


### PR DESCRIPTION
## Application Changes

- Add `/v1.0` and `/v1.0/docs` routes that redirect back to `/` as part of deprecating Stats API v1.0
- Remove links to Stats API v1.0 docs and update v1.0 deprecation message