### PR TITLE
Bump dependency versions for fastapi, uvicorn, wwdtm, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ static/robots.txt
 # Ignore New Relic Agent config file
 newrelic.ini
 
+# Deprecated files
+pytest.ini.old
+
 # Ignore macOS DS_Store files
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2.1.2
+
+### Application Changes
+
+- Add `/v1.0` and `/v1.0/docs` routes that redirect back to `/` as part of deprecating Stats API v1.0
+- Remove links to Stats API v1.0 docs and update v1.0 deprecation message
+
 ## 2.1.1
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changes
 
+## 2.1.3
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.8 to 2.0.9, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
+  - Upgrade NumPy from 1.23.4 to 1.24.2
+  - Upgrade python-slugify from 6.1.2 to 8.0.1
+  - Upgrade pytz from 2022.6 to 2023.3
+- Upgrade fastapi from 0.88.0 to 0.95.1
+- Upgrade httpx from 0.23.1 to 0.24.0
+- Upgrade uvicorn from 0.20.0 to 0.21.1
+- Upgrade aiofiles from 22.1.0 to 23.1.0
+- Upgrade email-validator from 1.3.0 to 1.3.1
+- Upgrade requests from 2.28.1 to 2.28.2
+
+### Development Changes
+
+- Move pytest configuration from `pytest.ini` into `pyproject.toml`
+- Upgrade flake8 from 5.0.4 to 6.0.0
+- Upgrade pycodestyle from 2.9.1 to 2.10.0
+- Upgrade pytest from 7.2.0 to 7.3.1
+- Upgrade black from 22.10.0 to 23.3.0
+
 ## 2.1.2
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.1.2"
+APP_VERSION = "2.1.3"
 
 
 def load_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [tool.black]
-required-version = "22.10.0"
+required-version = "23.3.0"
 target-version = ["py38", "py39", "py310", "py311"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+filterwarnings = [
+    "ignore::DeprecationWarning:mysql.*:",
+]
+norecursedirs = [
+    ".git",
+    "venv",
+    "static",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:mysql.*:
-norecursedirs = .git venv static

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
-flake8==5.0.4
-pycodestyle==2.9.1
-pytest==7.2.0
-black==22.10.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.3.1
+black==23.3.0
 
-fastapi==0.88.0
-uvicorn[standard]==0.20.0
+fastapi==0.95.1
+uvicorn[standard]==0.21.1
 gunicorn==20.1.0
-httpx==0.23.1
-aiofiles==22.1.0
+httpx==0.24.0
+aiofiles==23.1.0
 jinja2==3.1.2
-email-validator==1.3.0
-requests==2.28.1
+email-validator==1.3.1
+requests==2.28.2
 
-wwdtm==2.0.8
+wwdtm==2.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.88.0
-uvicorn[standard]==0.20.0
+fastapi==0.95.1
+uvicorn[standard]==0.21.1
 gunicorn==20.1.0
-httpx==0.23.1
-aiofiles==22.1.0
+httpx==0.24.0
+aiofiles==23.1.0
 jinja2==3.1.2
-email-validator==1.3.0
-requests==2.28.1
+email-validator==1.3.1
+requests==2.28.2
 
-wwdtm==2.0.8
+wwdtm==2.0.9


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.0.8 to 2.0.9, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
  - Upgrade NumPy from 1.23.4 to 1.24.2
  - Upgrade python-slugify from 6.1.2 to 8.0.1
  - Upgrade pytz from 2022.6 to 2023.3
- Upgrade fastapi from 0.88.0 to 0.95.1
- Upgrade httpx from 0.23.1 to 0.24.0
- Upgrade uvicorn from 0.20.0 to 0.21.1
- Upgrade aiofiles from 22.1.0 to 23.1.0
- Upgrade email-validator from 1.3.0 to 1.3.1
- Upgrade requests from 2.28.1 to 2.28.2

## Development Changes

- Move pytest configuration from `pytest.ini` into `pyproject.toml`
- Upgrade flake8 from 5.0.4 to 6.0.0
- Upgrade pycodestyle from 2.9.1 to 2.10.0
- Upgrade pytest from 7.2.0 to 7.3.1
- Upgrade black from 22.10.0 to 23.3.0