### PR TITLE
Update fastapi, uvicorn, httpx, requests and wwdtm dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 2.1.4
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.9 to 2.1.0
+- Upgrade fastapi from 0.95.1 to 0.98.0
+- Upgrade uvicorn from 0.21.0 to 0.22.0
+- Upgrade httpx from 0.24.0 to 0.24.1
+- Upgrade requests from 2.28.2 to 2.31.0
+
 ## 2.1.3
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.1.3"
+APP_VERSION = "2.1.4"
 
 
 def load_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,13 @@ pycodestyle==2.10.0
 pytest==7.3.1
 black==23.3.0
 
-fastapi==0.95.1
-uvicorn[standard]==0.21.1
+fastapi==0.98.0
+uvicorn[standard]==0.22.0
 gunicorn==20.1.0
-httpx==0.24.0
+httpx==0.24.1
 aiofiles==23.1.0
 jinja2==3.1.2
 email-validator==1.3.1
-requests==2.28.2
+requests==2.31.0
 
-wwdtm==2.0.9
+wwdtm==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.95.1
-uvicorn[standard]==0.21.1
+fastapi==0.98.0
+uvicorn[standard]==0.22.0
 gunicorn==20.1.0
-httpx==0.24.0
+httpx==0.24.1
 aiofiles==23.1.0
 jinja2==3.1.2
 email-validator==1.3.1
-requests==2.28.2
+requests==2.31.0
 
-wwdtm==2.0.9
+wwdtm==2.1.0


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.0.9 to 2.1.0
- Upgrade fastapi from 0.95.1 to 0.98.0
- Upgrade uvicorn from 0.21.0 to 0.22.0
- Upgrade httpx from 0.24.0 to 0.24.1
- Upgrade requests from 2.28.2 to 2.31.0