### PR TITLE
Bump dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2.2.0
+
+### Component Changes
+
+- Upgrade fastpi from 0.98.0 to 0.101.0
+- Upgrade uvicorn from 0.22.0 to 0.23.2
+- Upgrade gunicorn from 20.1.0 to 21.2.0
+- Upgrade aiofiles from 23.1.0 to 23.2.1
+- Upgrade email-validator from 1.3.1 to 2.0.0.post2
+
+### Development Changes
+
+- Upgrade flake8 from 6.0.0 to 6.1.0
+- Upgrade pycodestyle from 2.10.0 to 2.11.0
+- Upgrade pytest from 7.3.1 to 7.4.0
+- Upgrade black from 23.3.0 to 23.7.0
+
 ## 2.1.4
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.1.4"
+APP_VERSION = "2.2.0"
 
 
 def load_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-required-version = "23.3.0"
+required-version = "23.7.0"
 target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
-flake8==6.0.0
-pycodestyle==2.10.0
-pytest==7.3.1
-black==23.3.0
+flake8==6.1.0
+pycodestyle==2.11.0
+pytest==7.4.0
+black==23.7.0
 
-fastapi==0.98.0
-uvicorn[standard]==0.22.0
-gunicorn==20.1.0
+fastapi==0.101.0
+uvicorn[standard]==0.23.2
+gunicorn==21.2.0
 httpx==0.24.1
-aiofiles==23.1.0
+aiofiles==23.2.1
 jinja2==3.1.2
-email-validator==1.3.1
+email-validator==2.0.0.post2
 requests==2.31.0
 
 wwdtm==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.98.0
-uvicorn[standard]==0.22.0
-gunicorn==20.1.0
+fastapi==0.101.0
+uvicorn[standard]==0.23.2
+gunicorn==21.2.0
 httpx==0.24.1
-aiofiles==23.1.0
+aiofiles==23.2.1
 jinja2==3.1.2
-email-validator==1.3.1
+email-validator==2.0.0.post2
 requests==2.31.0
 
 wwdtm==2.1.0


### PR DESCRIPTION
## Component Changes

- Upgrade fastpi from 0.98.0 to 0.101.0
- Upgrade uvicorn from 0.22.0 to 0.23.2
- Upgrade gunicorn from 20.1.0 to 21.2.0
- Upgrade aiofiles from 23.1.0 to 23.2.1
- Upgrade email-validator from 1.3.1 to 2.0.0.post2

## Development Changes

- Upgrade flake8 from 6.0.0 to 6.1.0
- Upgrade pycodestyle from 2.10.0 to 2.11.0
- Upgrade pytest from 7.3.1 to 7.4.0
- Upgrade black from 23.3.0 to 23.7.0