### PR TITLE
Add Support for Panelist Decimal Scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Component Changes
 
-- Upgrade wwdtm from 2.2.0 to 2.3.0
+- Upgrade wwdtm from 2.1.0 to 2.2.0
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2.3.0
+
+### Application Changes
+
+- Add support for new column in the Wait Wait Stats Database that stores panelist scores as a decimal
+- Add a new settings configuration key, `use_decimal_scores`, to enable or disable the new feature
+
+### Component Changes
+
+- Upgrade wwdtm from 2.2.0 to 2.3.0
+
 ## 2.2.0
 
 ### Component Changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,9 +60,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-dev@wwdt.me. All complaints will be reviewed and investigated promptly and
-fairly.
+reported to the community leaders responsible for enforcement at [dev@wwdt.me](mailto:dev@wwdt.me).
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.2.0"
+APP_VERSION = "2.3.0"
 
 
 def load_config(
@@ -32,6 +32,7 @@ def load_config(
         config_dict = json.load(config_file)
 
     settings_config = config_dict.get("settings", None)
+    settings_config["use_decimal_scores"] = bool(settings_config.get("use_decimal_scores", False))
 
     if "database" in config_dict:
         database_config = config_dict["database"]

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -5,6 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Panelists Models"""
 
+from decimal import Decimal
 from typing import List, Optional, Tuple
 from pydantic import BaseModel, conint, Field
 
@@ -33,6 +34,17 @@ class ScoringStatistics(BaseModel):
     median: float = Field(title="Median Score")
     standard_deviation: float = Field(title="Standard Deviation")
     total: int = Field("Score Total")
+
+
+class DecimalScoringStatistics(BaseModel):
+    """Scoring Statistics"""
+
+    minimum: Decimal = Field(title="Minimum Score")
+    maximum: Decimal = Field(title="Maximum Score")
+    mean: Decimal = Field(title="Mean Score")
+    median: Decimal = Field(title="Median Score")
+    standard_deviation: Decimal = Field(title="Standard Deviation")
+    total: Decimal = Field("Score Total")
 
 
 class RankingCounts(BaseModel):
@@ -69,6 +81,9 @@ class PanelistStatistics(BaseModel):
 
     scoring: Optional[ScoringStatistics] = Field(
         default=None, title="Scoring Statistics"
+    )
+    scoring_decimal: Optional[DecimalScoringStatistics] = Field(
+        default=None, title="Decimal Scoring Statistics"
     )
     ranking: Optional[PanelistRankings] = Field(
         default=None, title="Ranking Percentages"
@@ -131,6 +146,7 @@ class ShowAppearance(BaseModel):
         default=None, title="Lightning Round Correct Answers"
     )
     score: Optional[int] = Field(default=None, title="Total Score")
+    score_decimal: Optional[Decimal] = Field(default=None, title="Total Decimal Score")
     rank: Optional[str] = Field(default=None, title="Ranking Position")
 
 

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -5,6 +5,7 @@
 # api.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Models"""
 
+from decimal import Decimal
 from typing import List, Optional, Union
 from pydantic import BaseModel, conint, Field
 
@@ -66,6 +67,7 @@ class ShowPanelist(BaseModel):
         default=None, title="Lightning Fill-in-the-Blank Corect Answers"
     )
     score: Union[int, None] = Field(default=None, title="Panelist Score")
+    score_decimal: Optional[Decimal] = Field(default=None, title="Panelist Decimal Score")
     rank: Union[str, None] = Field(default=None, title="Panelist Rank")
 
 

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -145,7 +145,9 @@ async def get_panelists_details():
     sorted by show date."""
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelists = panelist.retrieve_all_details()
+        panelists = panelist.retrieve_all_details(
+            use_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not panelists:
             raise HTTPException(status_code=404, detail="No panelists found")
         else:
@@ -177,7 +179,9 @@ async def get_panelist_details_by_id(panelist_id: conint(ge=0, lt=2**31)):
     Panelist appearances are sorted by show date."""
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_details_by_id(panelist_id)
+        panelist_details = panelist.retrieve_details_by_id(
+            panelist_id, use_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not panelist_details:
             raise HTTPException(
                 status_code=404, detail=f"Panelist ID {panelist_id} not found"
@@ -215,7 +219,9 @@ async def get_panelist_details_by_slug(panelist_slug: constr(strip_whitespace=Tr
     Panelist appearances are sorted by show date."""
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_details_by_slug(panelist_slug)
+        panelist_details = panelist.retrieve_details_by_slug(
+            panelist_slug, use_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not panelist_details:
             raise HTTPException(
                 status_code=404,

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -322,7 +322,9 @@ async def get_shows_details():
     Results are sorted by show date."""
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_all_details()
+        shows = show.retrieve_all_details(
+            include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not shows:
             raise HTTPException(status_code=404, detail="No shows found")
         else:
@@ -352,7 +354,10 @@ async def get_show_details_by_date_string(show_date: date):
     Panelists, Guests and other information."""
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_date_string(show_date.isoformat())
+        show_details = show.retrieve_details_by_date_string(
+            show_date.isoformat(),
+            include_decimal_scores=_config["settings"]["use_decimal_scores"],
+        )
         if not show_details:
             raise HTTPException(
                 status_code=404, detail=f"Show date {show_date} not found"
@@ -389,7 +394,9 @@ async def get_shows_details_by_year(year: conint(ge=1998, le=9999)):
     Results are sorted by show date."""
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_year(year)
+        shows = show.retrieve_details_by_year(
+            year, include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not shows:
             raise HTTPException(
                 status_code=404, detail=f"Shows for {year:04d} not found"
@@ -428,7 +435,11 @@ async def get_shows_details_by_year_month(
     Results are sorted by show date."""
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_year_month(year, month)
+        shows = show.retrieve_details_by_year_month(
+            year,
+            month,
+            include_decimal_scores=_config["settings"]["use_decimal_scores"],
+        )
         if not shows:
             raise HTTPException(
                 status_code=404, detail=f"Shows for {year:04d}-{month:02d} not found"
@@ -466,7 +477,9 @@ async def get_show_details_by_month_day(
     ID, date, Host, Scorekeeper, Panelists, Guests and other information."""
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_month_day(month, day)
+        shows = show.retrieve_details_by_month_day(
+            month, day, include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not shows:
             raise HTTPException(
                 status_code=404,
@@ -507,7 +520,12 @@ async def get_show_details_by_date(
     information."""
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_date(year, month, day)
+        show_details = show.retrieve_details_by_date(
+            year,
+            month,
+            day,
+            include_decimal_scores=_config["settings"]["use_decimal_scores"],
+        )
         if not show_details:
             raise HTTPException(
                 status_code=404,
@@ -545,7 +563,9 @@ async def get_show_details_by_id(show_id: conint(ge=0, lt=2**31)):
     date, Host, Scorekeeper, Panelists, Guests and other information."""
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_id(show_id)
+        show_details = show.retrieve_details_by_id(
+            show_id, include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not show_details:
             raise HTTPException(status_code=404, detail=f"Show ID {show_id} not found")
         else:
@@ -580,7 +600,9 @@ async def get_shows_recent_details():
     Results are sorted by show date."""
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_recent_details()
+        shows = show.retrieve_recent_details(
+            include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
         if not shows:
             raise HTTPException(status_code=404, detail="No recent shows found")
         else:

--- a/config.json.dist
+++ b/config.json.dist
@@ -19,6 +19,7 @@
         "stats_url": "https://stats.wwdt.me/",
         "contact_email": "",
         "contact_name": "",
-        "contact_url": ""
+        "contact_url": "",
+        "use_decimal_scores": false
     }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.1.0
+wwdtm==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.1.0
+wwdtm==2.2.0


### PR DESCRIPTION
## Application Changes

- Add support for new column in the Wait Wait Stats Database that stores panelist scores as a decimal
- Add a new settings configuration key, `use_decimal_scores`, to enable or disable the new feature

## Component Changes

- Upgrade wwdtm from 2.1.0 to 2.2.0