### PR TITLE
Change Pydantic dependency to <2 instead of ==1.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.1
+
+### Component Changes
+
+- Change pydantic version pin from "==1.10.12" to "<2" to include potential future updates to 1.x while blocking 2.x or higher
+
 ## 2.3.0
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.3.0"
+APP_VERSION = "2.3.1"
 
 
 def load_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pycodestyle==2.11.0
 pytest==7.4.0
 black==23.7.0
 
-pydantic==1.10.12
+pydantic<2
 fastapi==0.103.0
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==1.10.12
+pydantic<2
 fastapi==0.103.0
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0


### PR DESCRIPTION
## Component Changes

- Change pydantic version pin from "==1.10.12" to "<2" to include potential future updates to 1.x while blocking 2.x or higher