### PR TITLE
Fix issue where scores are returned as int rather than Decimal for panelist/scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.2
+
+### Application Changes
+
+- Fix issue where `panelists/scores/id` and `panelists/scores/slug` return scores as `int` instead of `Decimal` due to `Union[int, Decimal]` would return an `int`. Switched to `Union[Decimal, int]` to allow `Decimal` to take precedence
+
 ## 2.3.1
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.3.1"
+APP_VERSION = "2.3.2"
 
 
 def load_config(

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -6,7 +6,7 @@
 """Panelists Models"""
 
 from decimal import Decimal
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from pydantic import BaseModel, conint, Field
 
 
@@ -193,7 +193,7 @@ class PanelistScoresList(BaseModel):
     shows: Optional[List[str]] = Field(
         default=None, title="List of Panelist Appearances as Show Dates"
     )
-    scores: Optional[List[int]] = Field(default=None, title="List of Panelist Scores")
+    scores: Optional[List[Union[Decimal, int]]] = Field(default=None, title="List of Panelist Scores")
 
 
 class ScoresOrderedPair(BaseModel):


### PR DESCRIPTION
## Application Changes

- Fix issue where `panelists/scores/id` and `panelists/scores/slug` return scores as `int` instead of `Decimal` due to `Union[int, Decimal]` would return an `int`. Switched to `Union[Decimal, int]` to allow `Decimal` to take precedence