### PR TITLE
Adding support for panelist lightning start/correct decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2.4.0
+
+### Application Changes
+
+- Add support for Panelist Lightning Start and Correct decimal fields for the appropriate models
+- Panelist Lightning Start and Correct decimal values will be added as additional fields rather than replacing the current fields
+
+### Component Changes
+
+- Upgrade wwdtm from 2.2.0 to 2.3.0
+
 ## 2.3.2
 
 ### Application Changes

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -142,8 +142,14 @@ class ShowAppearance(BaseModel):
     lightning_round_start: Optional[int] = Field(
         default=None, title="Lightning Round Starting Score"
     )
+    lightning_round_start_decimal: Optional[Decimal] = Field(
+        default=None, title="Lightning Round Starting Decimal Score"
+    )
     lightning_round_correct: Optional[int] = Field(
         default=None, title="Lightning Round Correct Answers"
+    )
+    lightning_round_correct_decimal: Optional[Decimal] = Field(
+        default=None, title="Lightning Round Correct Answers (Decimal)"
     )
     score: Optional[int] = Field(default=None, title="Total Score")
     score_decimal: Optional[Decimal] = Field(default=None, title="Total Decimal Score")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -63,8 +63,14 @@ class ShowPanelist(BaseModel):
     lightning_round_start: Union[int, None] = Field(
         default=None, title="Lightning Fill-in-the-Blank Starting Score"
     )
+    lightning_round_start_decimal: Union[Decimal, None] = Field(
+        default=None, title="Lightning Fill-in-the-Blank Starting Decimal Score"
+    )
     lightning_round_correct: Union[int, None] = Field(
-        default=None, title="Lightning Fill-in-the-Blank Corect Answers"
+        default=None, title="Lightning Fill-in-the-Blank Correct Answers"
+    )
+    lightning_round_correct_decimal: Union[Decimal, None] = Field(
+        default=None, title="Lightning Fill-in-the-Blank Correct Answers (Decimal)"
     )
     score: Union[int, None] = Field(default=None, title="Panelist Score")
     score_decimal: Optional[Decimal] = Field(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.2.0
+wwdtm==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.2.0
+wwdtm==2.3.0


### PR DESCRIPTION
## Application Changes

- Add support for Panelist Lightning Start and Correct decimal fields for the appropriate models
- Panelist Lightning Start and Correct decimal values will be added as additional fields rather than replacing the current fields

## Component Changes

- Upgrade wwdtm from 2.2.0 to 2.3.0