### PR TITLE
Migrating to Pydantic 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2.5.0
+
+### Application Changes
+
+- Migrate to Pydantic 2, which requires re-working of models, which includes:
+  - Using [bump-pydantic](https://github.com/pydantic/bump-pydantic) to migrate to Pydantic 2
+  - Replacing `conint` and `constr` with `Annotated[int, Path()]` and `Annotated[str, Path()]` respectively in routes
+  - Replacing `strip_whitespace=True` to `string.strip()` when passing in values to a method
+- Adding titles via `Path(title=)` to path elements in routes where applicable
+- Correct spelling errors
+
+### Component Changes
+
+- Upgrade wwdtm from 2.4.0 to 2.4.1, which includes:
+  - Upgrading numpy from 1.24.3 to 1.24.4
+  - Upgrading pytz from 2023.3 to 2023.3.post1
+
 ## 2.4.1
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.2
+
+### Application Changes
+
+- Fix issue where `panelists/scores/id` and `panelists/scores/slug` return scores as `int` instead of `Decimal` due to `Union[int, Decimal]` would return an `int`. Switched to `Union[Decimal, int]` to allow `Decimal` to take precedence
+
 ## 2.3.1
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.3.1
+
+### Component Changes
+
+- Change pydantic version pin from "==1.10.12" to "<2" to include potential future updates to 1.x while blocking 2.x or higher
+
 ## 2.3.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2.4.0
+
+### Application Changes
+
+- Add support for Panelist Lightning Start and Correct decimal fields for the appropriate models
+- Panelist Lightning Start and Correct decimal values will be added as additional fields rather than replacing the current fields
+
+### Component Changes
+
+- Upgrade wwdtm from 2.2.0 to 2.3.0
+
 ## 2.3.2
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.4.1"
+APP_VERSION = "2.5.0"
 
 
 def load_config(

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.3.2"
+APP_VERSION = "2.4.0"
 
 
 def load_config(

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.3.0"
+APP_VERSION = "2.3.1"
 
 
 def load_config(

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.3.1"
+APP_VERSION = "2.3.2"
 
 
 def load_config(

--- a/app/models/guests.py
+++ b/app/models/guests.py
@@ -6,13 +6,14 @@
 """Guests Models"""
 
 from typing import List, Optional, Union
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class Guest(BaseModel):
     """Not My Job Guest Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Guest ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Guest ID")
     name: str = Field(title="Guest Name")
     slug: Optional[str] = Field(default=None, title="Guest Slug String")
 
@@ -37,7 +38,7 @@ class GuestAppearanceCounts(BaseModel):
 class GuestAppearance(BaseModel):
     """Appearance Information"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -6,13 +6,14 @@
 """Hosts Models"""
 
 from typing import List, Optional, Union
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class Host(BaseModel):
     """Host Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Host ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Host ID")
     name: str = Field(title="Host Name")
     slug: Optional[str] = Field(default=None, title="Host Slug String")
     gender: Optional[str] = Field(default=None, title="Host Gender")
@@ -38,7 +39,7 @@ class HostAppearanceCounts(BaseModel):
 class HostAppearance(BaseModel):
     """Appearance Information"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -6,13 +6,14 @@
 """Locations Models"""
 
 from typing import List, Optional
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class Location(BaseModel):
     """Location Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Location ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Location ID")
     city: Optional[str] = Field(default=None, title="City")
     state: Optional[str] = Field(default=None, title="State")
     venue: Optional[str] = Field(default=None, title="Venue Name")
@@ -37,7 +38,7 @@ class LocationRecordingCounts(BaseModel):
 class LocationRecordingShow(BaseModel):
     """Location Recording Information"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -142,8 +142,14 @@ class ShowAppearance(BaseModel):
     lightning_round_start: Optional[int] = Field(
         default=None, title="Lightning Round Starting Score"
     )
+    lightning_round_start_decimal: Optional[Decimal] = Field(
+        default=None, title="Lightning Round Starting Decimal Score"
+    )
     lightning_round_correct: Optional[int] = Field(
         default=None, title="Lightning Round Correct Answers"
+    )
+    lightning_round_correct_decimal: Optional[Decimal] = Field(
+        default=None, title="Lightning Round Correct Answers (Decimal)"
     )
     score: Optional[int] = Field(default=None, title="Total Score")
     score_decimal: Optional[Decimal] = Field(default=None, title="Total Decimal Score")

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -6,7 +6,7 @@
 """Panelists Models"""
 
 from decimal import Decimal
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from pydantic import BaseModel, conint, Field
 
 
@@ -193,7 +193,7 @@ class PanelistScoresList(BaseModel):
     shows: Optional[List[str]] = Field(
         default=None, title="List of Panelist Appearances as Show Dates"
     )
-    scores: Optional[List[int]] = Field(default=None, title="List of Panelist Scores")
+    scores: Optional[List[Union[Decimal, int]]] = Field(default=None, title="List of Panelist Scores")
 
 
 class ScoresOrderedPair(BaseModel):

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -7,13 +7,14 @@
 
 from decimal import Decimal
 from typing import List, Optional, Tuple, Union
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field, RootModel
+from typing_extensions import Annotated
 
 
 class Panelist(BaseModel):
     """Panelist Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
     slug: Optional[str] = Field(default=None, title="Panelist Slug String")
     gender: Optional[str] = Field(default=None, title="Panelist Gender")
@@ -104,21 +105,23 @@ class PanelistBluffs(BaseModel):
 class MilestonesFirst(BaseModel):
     """Panelist First Appearance Milestone"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="First Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="First Show ID")
     show_date: str = Field(title="First Show Date")
 
 
 class MilestonesMostRecent(BaseModel):
     """Panelist Most Recent Appearance Milestone"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Most Recent Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(
+        title="Most Recent Show ID"
+    )
     show_date: str = Field(title="Most Recent Show Date")
 
 
 class AppearanceMilestones(BaseModel):
     """Panelist Appearance Milestones"""
 
-    first: Optional[MilestonesFirst] = Field(default=None, title="First Appearanace")
+    first: Optional[MilestonesFirst] = Field(default=None, title="First Appearance")
     most_recent: Optional[MilestonesMostRecent] = Field(
         default=None, title="Most Recent Appearance"
     )
@@ -135,7 +138,7 @@ class AppearanceCounts(BaseModel):
 class ShowAppearance(BaseModel):
     """Panelist Show Appearance Information"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")
@@ -204,10 +207,10 @@ class PanelistScoresList(BaseModel):
     )
 
 
-class ScoresOrderedPair(BaseModel):
+class ScoresOrderedPair(RootModel[Tuple]):
     """Tuple containing a show date and the corresponding score"""
 
-    __root__: Tuple = Field(title="Ordered Pair containing Show Date and Score")
+    pass
 
 
 class PanelistScoresOrderedPair(BaseModel):
@@ -219,14 +222,11 @@ class PanelistScoresOrderedPair(BaseModel):
     )
 
 
-class ScoresGroupedOrderedPair(BaseModel):
+class ScoresGroupedOrderedPair(RootModel[Tuple]):
     """Tuple containing a score and their corresponding number of times
     that score had been earned"""
 
-    __root__: Tuple = Field(
-        title="Ordered Pair containing score and number of "
-        "times that score had been earned"
-    )
+    pass
 
 
 class PanelistScoresGroupedOrderedPair(BaseModel):

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -6,13 +6,14 @@
 """Scorekeepers Models"""
 
 from typing import List, Optional, Union
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class Scorekeeper(BaseModel):
     """Scorekeeper Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Scorekeeper ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Scorekeeper ID")
     name: str = Field(title="Scorekeeper Name")
     slug: Optional[str] = Field(default=None, title="Scorekeeper Slug String")
     gender: Optional[str] = Field(default=None, title="Scorekeeper Gender")
@@ -38,7 +39,7 @@ class ScorekeeperAppearanceCounts(BaseModel):
 class ScorekeeperAppearance(BaseModel):
     """Appearance Information"""
 
-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -7,13 +7,14 @@
 
 from decimal import Decimal
 from typing import List, Optional, Union
-from pydantic import BaseModel, conint, Field
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 
 class Show(BaseModel):
     """Show Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Show ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Best Of Show")
@@ -28,7 +29,7 @@ class Shows(BaseModel):
 class ShowLocation(BaseModel):
     """Show Location Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Location ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Location ID")
     slug: Optional[str] = Field(default=None, title="Location Slug String")
     city: Optional[str] = Field(default=None, title="City")
     state: Optional[str] = Field(default=None, title="State")
@@ -38,7 +39,7 @@ class ShowLocation(BaseModel):
 class ShowHost(BaseModel):
     """Show Host Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Host ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Host ID")
     name: str = Field(title="Host Name")
     slug: Optional[str] = Field(default=None, title="Host Slug String")
     guest: bool = Field(title="Guest Host")
@@ -47,7 +48,7 @@ class ShowHost(BaseModel):
 class ShowScorekeeper(BaseModel):
     """Show Scorekeeper Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Scorekeeper ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Scorekeeper ID")
     name: str = Field(title="Scorekeeper Name")
     slug: Optional[str] = Field(default=None, title="Scorekeeper Slug String")
     guest: bool = Field(title="Guest Scorekeeper")
@@ -57,7 +58,7 @@ class ShowScorekeeper(BaseModel):
 class ShowPanelist(BaseModel):
     """Show Panelist Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
     slug: Optional[str] = Field(default=None, title="Panelist Slug String")
     lightning_round_start: Union[int, None] = Field(
@@ -82,7 +83,7 @@ class ShowPanelist(BaseModel):
 class ShowBluffPanelist(BaseModel):
     """Show Bluff the Listener Panelist Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
     slug: Optional[str] = Field(default=None, title="Panelist Slug String")
 
@@ -101,7 +102,7 @@ class ShowBluffDetails(BaseModel):
 class ShowGuest(BaseModel):
     """Show Guest Information"""
 
-    id: conint(ge=0, lt=2**31) = Field(title="Guest ID")
+    id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Guest ID")
     name: str = Field(title="Guest Name")
     slug: Optional[str] = Field(default=None, title="Guest Slug String")
     score: Union[int, None] = Field(default=None, title="Guest Score")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -63,8 +63,14 @@ class ShowPanelist(BaseModel):
     lightning_round_start: Union[int, None] = Field(
         default=None, title="Lightning Fill-in-the-Blank Starting Score"
     )
+    lightning_round_start_decimal: Union[Decimal, None] = Field(
+        default=None, title="Lightning Fill-in-the-Blank Starting Decimal Score"
+    )
     lightning_round_correct: Union[int, None] = Field(
-        default=None, title="Lightning Fill-in-the-Blank Corect Answers"
+        default=None, title="Lightning Fill-in-the-Blank Correct Answers"
+    )
+    lightning_round_correct_decimal: Union[Decimal, None] = Field(
+        default=None, title="Lightning Fill-in-the-Blank Correct Answers (Decimal)"
     )
     score: Union[int, None] = Field(default=None, title="Panelist Score")
     score_decimal: Optional[Decimal] = Field(

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -17,6 +17,7 @@ from app.models.guests import (
     GuestDetails as ModelsGuestDetails,
     GuestsDetails as ModelsGuestsDetails,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/guests")
 _config = load_config()
@@ -134,7 +135,7 @@ async def get_guests_details():
     """Retrieve an array of Not My Job Guest objects, each containing:
     Guest ID, name, slug string and their appearance details.
 
-    Results are sorted by guest name, with guest apperances sorted
+    Results are sorted by guest name, with guest appearances sorted
     by show date."""
     try:
         guest = Guest(database_connection=_database_connection)

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -6,10 +6,9 @@
 """API routes for Not My Job Guests endpoints"""
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.guest import Guest
 from app.models.guests import (
     Guest as ModelsGuest,
@@ -63,7 +62,9 @@ async def get_guests():
     tags=["Guests"],
 )
 @router.head("/id/{guest_id}", include_in_schema=False)
-async def get_guest_by_id(guest_id: conint(ge=0, lt=2**31)):
+async def get_guest_by_id(
+    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
+):
     """Retrieve a Not My Job Guest object, based on Guest ID,
     containing: Guest ID, name and slug string."""
     try:
@@ -96,12 +97,14 @@ async def get_guest_by_id(guest_id: conint(ge=0, lt=2**31)):
     tags=["Guests"],
 )
 @router.head("/slug/{guest_slug}", include_in_schema=False)
-async def get_guest_by_slug(guest_slug: constr(strip_whitespace=True)):
+async def get_guest_by_slug(
+    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+):
     """Retrieve a Not My Job Guest object, based on Guest slug string,
     containing: Guest ID, name and slug string."""
     try:
         guest = Guest(database_connection=_database_connection)
-        guest_info = guest.retrieve_by_slug(guest_slug)
+        guest_info = guest.retrieve_by_slug(guest_slug.strip())
         if not guest_info:
             raise HTTPException(
                 status_code=404, detail=f"Guest slug string {guest_slug} not found"
@@ -163,7 +166,9 @@ async def get_guests_details():
     tags=["Guests"],
 )
 @router.head("/details/id/{guest_id}", include_in_schema=False)
-async def get_guest_details_by_id(guest_id: conint(ge=0, lt=2**31)):
+async def get_guest_details_by_id(
+    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
+):
     """Retrieve a Not My Job Guest object, based on Guest ID,
     containing: Guest ID, name, slug string, and their appearance details.
 
@@ -198,14 +203,16 @@ async def get_guest_details_by_id(guest_id: conint(ge=0, lt=2**31)):
     tags=["Guests"],
 )
 @router.head("/details/slug/{guest_slug}", include_in_schema=False)
-async def get_guest_details_by_slug(guest_slug: constr(strip_whitespace=True)):
+async def get_guest_details_by_slug(
+    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+):
     """Retrieve a Not My Job Guest object, based on Guest slug string,
     containing: Guest ID, name, slug string, and their appearance details.
 
     Guest appearances are sorted by show date."""
     try:
         guest = Guest(database_connection=_database_connection)
-        guest_details = guest.retrieve_details_by_slug(guest_slug)
+        guest_details = guest.retrieve_details_by_slug(guest_slug.strip())
         if not guest_details:
             raise HTTPException(
                 status_code=404, detail=f"Guest slug string {guest_slug} not found"

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -6,10 +6,9 @@
 """API routes for Hosts endpoints"""
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.host import Host
 from app.models.hosts import (
     Host as ModelsHost,
@@ -63,7 +62,9 @@ async def get_hosts():
     tags=["Hosts"],
 )
 @router.head("/id/{host_id}", include_in_schema=False)
-async def get_host_by_id(host_id: conint(ge=0, lt=2**31)):
+async def get_host_by_id(
+    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
+):
     """Retrieve a Host object, based on Host ID, containing: Host ID,
     name, slug string, and gender."""
     try:
@@ -94,7 +95,9 @@ async def get_host_by_id(host_id: conint(ge=0, lt=2**31)):
     tags=["Hosts"],
 )
 @router.head("/slug/{host_slug}", include_in_schema=False)
-async def get_host_by_slug(host_slug: constr(strip_whitespace=True)):
+async def get_host_by_slug(
+    host_slug: Annotated[str, Path(title="The slug string of the host to get")]
+):
     """Retrieve a Host object, based on Host slug string, containing:
     Host ID, name, slug string, and gender."""
     try:
@@ -161,7 +164,9 @@ async def get_hosts_details():
     tags=["Hosts"],
 )
 @router.head("/details/id/{host_id}", include_in_schema=False)
-async def get_host_details_by_id(host_id: conint(ge=0, lt=2**31)):
+async def get_host_details_by_id(
+    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
+):
     """Retrieve a Host object, based on Host ID, containing: Host ID,
     name, slug string, gender, and their appearance details.
 
@@ -194,7 +199,9 @@ async def get_host_details_by_id(host_id: conint(ge=0, lt=2**31)):
     tags=["Hosts"],
 )
 @router.head("/details/slug/{host_slug}", include_in_schema=False)
-async def get_host_details_by_slug(host_slug: constr(strip_whitespace=True)):
+async def get_host_details_by_slug(
+    host_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+):
     """Retrieve a Host object, based on Host slug string, containing:
     Host ID, name, slug string, gender, and their appearance details.
 

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -17,6 +17,7 @@ from app.models.hosts import (
     HostDetails as ModelsHostDetails,
     HostsDetails as ModelsHostsDetails,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
 _config = load_config()
@@ -132,7 +133,7 @@ async def get_hosts_details():
     """Retrieve an array of Host objects, each containing: Host ID,
     name, slug string, gender, and their appearance details.
 
-    Results are sorted by host name, with host apperances sorted by
+    Results are sorted by host name, with host appearances sorted by
     show date."""
     try:
         host = Host(database_connection=_database_connection)

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -6,10 +6,9 @@
 """API routes for Locations endpoints"""
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.location import Location
 from app.models.locations import (
     Location as ModelsLocation,
@@ -63,7 +62,11 @@ async def get_locations():
     tags=["Locations"],
 )
 @router.head("/id/{location_id}", include_in_schema=False)
-async def get_location_by_id(location_id: conint(ge=0, lt=2**31)):
+async def get_location_by_id(
+    location_id: Annotated[
+        int, Path(title="The ID of the location to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Location object, based on Location ID, containing:
     Location ID, city, state, venue, and slug string."""
     try:
@@ -98,12 +101,14 @@ async def get_location_by_id(location_id: conint(ge=0, lt=2**31)):
     tags=["Locations"],
 )
 @router.head("/slug/{location_slug}", include_in_schema=False)
-async def get_location_by_slug(location_slug: constr(strip_whitespace=True)):
+async def get_location_by_slug(
+    location_slug: Annotated[str, Path(title="The slug string of the location to get")]
+):
     """Retrieve a location object, based on Location slug string,
     containing: Location ID, city, state, venue, and slug string."""
     try:
         location = Location(database_connection=_database_connection)
-        location_info = location.retrieve_by_slug(location_slug)
+        location_info = location.retrieve_by_slug(location_slug.strip())
         if not location_info:
             raise HTTPException(
                 status_code=404,
@@ -166,7 +171,11 @@ async def get_locations_details():
     tags=["Locations"],
 )
 @router.head("/recordings/id/{location_id}", include_in_schema=False)
-async def get_location_recordings_by_id(location_id: conint(ge=0, lt=2**31)):
+async def get_location_recordings_by_id(
+    location_id: Annotated[
+        int, Path(title="The ID of the location to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Location object, based on Location ID, containing:
     Location ID, city, state, venue, slug string, and an array of
     recordings.
@@ -204,7 +213,9 @@ async def get_location_recordings_by_id(location_id: conint(ge=0, lt=2**31)):
     tags=["Locations"],
 )
 @router.head("/recordings/slug/{location_slug}", include_in_schema=False)
-async def get_location_recordings_by_slug(location_slug: constr(strip_whitespace=True)):
+async def get_location_recordings_by_slug(
+    location_slug: Annotated[str, Path(title="The slug string of the location to get")]
+):
     """Retrieve a Location object, based on Location slug string,
     containing: Location ID, city, state, venue, slug string, and an
     array of recordings.
@@ -212,7 +223,7 @@ async def get_location_recordings_by_slug(location_slug: constr(strip_whitespace
     Recordings are sorted by show date."""
     try:
         location = Location(database_connection=_database_connection)
-        location_details = location.retrieve_details_by_slug(location_slug)
+        location_details = location.retrieve_details_by_slug(location_slug.strip())
         if not location_details:
             raise HTTPException(
                 status_code=404,

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -17,6 +17,7 @@ from app.models.locations import (
     LocationDetails as ModelsLocationDetails,
     LocationsDetails as ModelsLocationsDetails,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/locations")
 _config = load_config()

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -20,6 +20,7 @@ from app.models.panelists import (
     PanelistScoresOrderedPair as ModelsPanelistScoresOrderedPair,
     PanelistScoresGroupedOrderedPair as ModelsPanelistScoresGroupedOrderedPair,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/panelists")
 _config = load_config()
@@ -141,7 +142,7 @@ async def get_panelists_details():
     Panelists ID, name, slug string, gender, and their statistics
     and appearance details.
 
-    Results are sorted by panelist name, with panelist apperances
+    Results are sorted by panelist name, with panelist appearances
     sorted by show date."""
     try:
         panelist = Panelist(database_connection=_database_connection)
@@ -341,7 +342,7 @@ async def get_panelist_scores_by_slug(panelist_slug: constr(strip_whitespace=Tru
 )
 @router.head("/scores/grouped-ordered-pair/id/{panelist_id}", include_in_schema=False)
 async def get_panelist_scores_grouped_ordered_pair_by_id(
-    panelist_id: conint(ge=0, lt=2**31)
+    panelist_id: Annotated[int, conint(ge=0, lt=2**31)]
 ):
     """Retrieve Panelist scores, based on Panelist ID, as grouped
     ordered pairs, each pair containing a score and the corresponding

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -6,10 +6,9 @@
 """API routes for Panelists endpoints"""
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.panelist import Panelist, PanelistDecimalScores, PanelistScores
 from app.models.panelists import (
     Panelist as ModelsPanelist,
@@ -66,7 +65,11 @@ async def get_panelists():
     tags=["Panelists"],
 )
 @router.head("/id/{panelist_id}", include_in_schema=False)
-async def get_panelist_by_id(panelist_id: conint(ge=0, lt=2**31)):
+async def get_panelist_by_id(
+    panelist_id: Annotated[
+        int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Panelist object, based on Panelist ID, containing:
     Panelist ID, name, slug string, and gender."""
     try:
@@ -101,12 +104,14 @@ async def get_panelist_by_id(panelist_id: conint(ge=0, lt=2**31)):
     tags=["Panelists"],
 )
 @router.head("/slug/{panelist_slug}", include_in_schema=False)
-async def get_panelist_by_slug(panelist_slug: constr(strip_whitespace=True)):
+async def get_panelist_by_slug(
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+):
     """Retrieve a Panelist object, based on Panelist slug string,
     containing: Panelist ID, name, slug string, and gender."""
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_info = panelist.retrieve_by_slug(panelist_slug)
+        panelist_info = panelist.retrieve_by_slug(panelist_slug.strip())
         if not panelist_info:
             raise HTTPException(
                 status_code=404,
@@ -172,7 +177,11 @@ async def get_panelists_details():
     tags=["Panelists"],
 )
 @router.head("/details/id/{panelist_id}", include_in_schema=False)
-async def get_panelist_details_by_id(panelist_id: conint(ge=0, lt=2**31)):
+async def get_panelist_details_by_id(
+    panelist_id: Annotated[
+        int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Panelist object, based on Panelist ID, containing:
     Panelist ID, name, slug string, gender, and their statistics and
     appearance details.
@@ -212,7 +221,9 @@ async def get_panelist_details_by_id(panelist_id: conint(ge=0, lt=2**31)):
     tags=["Panelists"],
 )
 @router.head("/details/slug/{panelist_slug}", include_in_schema=False)
-async def get_panelist_details_by_slug(panelist_slug: constr(strip_whitespace=True)):
+async def get_panelist_details_by_slug(
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+):
     """Retrieve a Panelist object, based on Panelist slug string,
     containing: Panelist ID, name, slug string, gender, and their
     statistics and appearance details.
@@ -221,7 +232,8 @@ async def get_panelist_details_by_slug(panelist_slug: constr(strip_whitespace=Tr
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_details = panelist.retrieve_details_by_slug(
-            panelist_slug, use_decimal_scores=_config["settings"]["use_decimal_scores"]
+            panelist_slug.strip(),
+            use_decimal_scores=_config["settings"]["use_decimal_scores"],
         )
         if not panelist_details:
             raise HTTPException(
@@ -253,7 +265,11 @@ async def get_panelist_details_by_slug(panelist_slug: constr(strip_whitespace=Tr
     tags=["Panelists"],
 )
 @router.head("/scores/id/{panelist_id}", include_in_schema=False)
-async def get_panelist_scores_by_id(panelist_id: conint(ge=0, lt=2**31)):
+async def get_panelist_scores_by_id(
+    panelist_id: Annotated[
+        int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve Panelist scores, based on Panelist ID, as a pair of
     lists, one list of show dates and one list of corresponding scores."""
     try:
@@ -297,7 +313,9 @@ async def get_panelist_scores_by_id(panelist_id: conint(ge=0, lt=2**31)):
     tags=["Panelists"],
 )
 @router.head("/scores/slug/{panelist_slug}", include_in_schema=False)
-async def get_panelist_scores_by_slug(panelist_slug: constr(strip_whitespace=True)):
+async def get_panelist_scores_by_slug(
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+):
     """Retrieve Panelist scores, based on Panelist slug string, as a
     pair of lists, one list of show dates and one list of corresponding
     scores."""
@@ -306,10 +324,10 @@ async def get_panelist_scores_by_slug(panelist_slug: constr(strip_whitespace=Tru
             panelist_scores = PanelistDecimalScores(
                 database_connection=_database_connection
             )
-            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug)
+            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug.strip())
         else:
             panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug)
+            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug.strip())
         if not scores:
             raise HTTPException(
                 status_code=404,
@@ -342,7 +360,9 @@ async def get_panelist_scores_by_slug(panelist_slug: constr(strip_whitespace=Tru
 )
 @router.head("/scores/grouped-ordered-pair/id/{panelist_id}", include_in_schema=False)
 async def get_panelist_scores_grouped_ordered_pair_by_id(
-    panelist_id: Annotated[int, conint(ge=0, lt=2**31)]
+    panelist_id: Annotated[
+        int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
+    ]
 ):
     """Retrieve Panelist scores, based on Panelist ID, as grouped
     ordered pairs, each pair containing a score and the corresponding
@@ -395,7 +415,7 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
     "/scores/grouped-ordered-pair/slug/{panelist_slug}", include_in_schema=False
 )
 async def get_panelist_scores_grouped_ordered_pair_by_slug(
-    panelist_slug: constr(strip_whitespace=True),
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
     """Retrieve Panelist scores, based on Panelist slug string, as
     grouped ordered pairs, each pair containing a score and the
@@ -407,12 +427,12 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
                 database_connection=_database_connection
             )
             scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_slug(
-                panelist_slug
+                panelist_slug.strip()
             )
         else:
             panelist_scores = PanelistScores(database_connection=_database_connection)
             scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_slug(
-                panelist_slug
+                panelist_slug.strip()
             )
         if not scores:
             raise HTTPException(
@@ -444,7 +464,11 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
     tags=["Panelists"],
 )
 @router.head("/scores/ordered-pair/id/{panelist_id}", include_in_schema=False)
-async def get_panelist_scores_ordered_pair_by_id(panelist_id: conint(ge=0, lt=2**31)):
+async def get_panelist_scores_ordered_pair_by_id(
+    panelist_id: Annotated[
+        int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve Panelist scores, based on Panelist ID, as ordered
     pairs, each pair containing the show date and the corresponding
     score.
@@ -489,7 +513,7 @@ async def get_panelist_scores_ordered_pair_by_id(panelist_id: conint(ge=0, lt=2*
 )
 @router.head("/scores/ordered-pair/slug/{panelist_slug}", include_in_schema=False)
 async def get_panelist_scores_ordered_pair_by_slug(
-    panelist_slug: constr(strip_whitespace=True),
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
     """Retrieve Panelist scores, based on Panelist slug string, as
     ordered pairs, each pair containing the show date and the
@@ -500,10 +524,14 @@ async def get_panelist_scores_ordered_pair_by_slug(
             panelist_scores = PanelistDecimalScores(
                 database_connection=_database_connection
             )
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(panelist_slug)
+            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(
+                panelist_slug.strip()
+            )
         else:
             panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(panelist_slug)
+            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(
+                panelist_slug.strip()
+            )
         if not scores:
             raise HTTPException(
                 status_code=404,

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -6,10 +6,9 @@
 """API routes for Scorekeeper endpoints"""
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.scorekeeper import Scorekeeper
 from app.models.scorekeepers import (
     Scorekeeper as ModelsScorekeeper,
@@ -63,7 +62,11 @@ async def get_scorekeepers():
     tags=["Scorekeepers"],
 )
 @router.head("/id/{scorekeeper_id}", include_in_schema=False)
-async def get_scorekeeper_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
+async def get_scorekeeper_by_id(
+    scorekeeper_id: Annotated[
+        int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Scorekeeper object, based on Scorekeeper ID,
     containing: Scorekeeper ID, name, slug string, and gender."""
     try:
@@ -98,12 +101,16 @@ async def get_scorekeeper_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
     tags=["Scorekeepers"],
 )
 @router.head("/slug/{scorekeeper_slug}", include_in_schema=False)
-async def get_scorekeeper_by_slug(scorekeeper_slug: constr(strip_whitespace=True)):
+async def get_scorekeeper_by_slug(
+    scorekeeper_slug: Annotated[
+        str, Path(title="The slug string of the scorekeeper to get")
+    ]
+):
     """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
     containing: Scorekeeper ID, name, slug string, and gender."""
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
-        scorekeeper_info = scorekeeper.retrieve_by_slug(scorekeeper_slug)
+        scorekeeper_info = scorekeeper.retrieve_by_slug(scorekeeper_slug.strip())
         if not scorekeeper_info:
             raise HTTPException(
                 status_code=404,
@@ -168,7 +175,11 @@ async def get_scorekeepers_details():
     tags=["Scorekeepers"],
 )
 @router.head("/details/id/{scorekeeper_id}", include_in_schema=False)
-async def get_scorekeeper_details_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
+async def get_scorekeeper_details_by_id(
+    scorekeeper_id: Annotated[
+        int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
+    ]
+):
     """Retrieve a Scorekeeper object, based on Scorekeeper ID,
     containing: Scorekeeper ID, name, slug string, gender, and their
     appearance details.
@@ -207,7 +218,9 @@ async def get_scorekeeper_details_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
 )
 @router.head("/details/slug/{scorekeeper_slug}", include_in_schema=False)
 async def get_scorekeeper_details_by_slug(
-    scorekeeper_slug: constr(strip_whitespace=True),
+    scorekeeper_slug: Annotated[
+        str, Path(title="The slug string of the scorekeeper to get")
+    ]
 ):
     """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
     containing: Scorekeeper ID, name, slug string, gender, and their
@@ -216,7 +229,9 @@ async def get_scorekeeper_details_by_slug(
     Scorekeeper appearances are sorted by show date."""
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
-        scorekeeper_details = scorekeeper.retrieve_details_by_slug(scorekeeper_slug)
+        scorekeeper_details = scorekeeper.retrieve_details_by_slug(
+            scorekeeper_slug.strip()
+        )
         if not scorekeeper_details:
             raise HTTPException(
                 status_code=404,

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -17,6 +17,7 @@ from app.models.scorekeepers import (
     ScorekeeperDetails as ModelsScorekeeperDetails,
     ScorekeepersDetails as ModelsScorekeepersDetails,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/scorekeepers")
 _config = load_config()
@@ -139,7 +140,7 @@ async def get_scorekeepers_details():
     Scorekeepers ID, name, slug string, gender, and their appearance
     details.
 
-    Results are sorted by scorekeeper name, with scorekeeper apperances
+    Results are sorted by scorekeeper name, with scorekeeper appearances
     sorted by show date."""
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -11,7 +11,7 @@ from app.config import API_VERSION, load_config
 from fastapi import APIRouter, HTTPException
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint
+from pydantic import conint, constr
 from wwdtm.show import Show
 from app.models.shows import (
     Show as ModelsShow,
@@ -20,6 +20,7 @@ from app.models.shows import (
     ShowDetails as ModelsShowDetails,
     ShowsDetails as ModelsShowsDetails,
 )
+from typing_extensions import Annotated
 
 router = APIRouter(prefix=f"/v{API_VERSION}/shows")
 _config = load_config()
@@ -246,7 +247,9 @@ async def get_show_by_month_day(month: conint(ge=1, le=12), day: conint(ge=1, le
 )
 @router.head("/date/{year}/{month}/{day}", include_in_schema=False)
 async def get_show_by_date(
-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12), day: conint(ge=1, le=31)
+    year: conint(ge=1998, le=9999),
+    month: conint(ge=1, le=12),
+    day: conint(ge=1, le=31),
 ):
     """Retrieve a Show object, based on year, month and day, containing:
     Show ID, date and basic information."""
@@ -426,7 +429,8 @@ async def get_shows_details_by_year(year: conint(ge=1998, le=9999)):
 )
 @router.head("/details/date/{year}/{month}", include_in_schema=False)
 async def get_shows_details_by_year_month(
-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12)
+    year: conint(ge=1998, le=9999),
+    month: conint(ge=1, le=12),
 ):
     """Retrieve an array of Show objects, based on year and month,
     containing: Show ID, date, Host, Scorekeeper, Panelists, Guests and
@@ -513,7 +517,9 @@ async def get_show_details_by_month_day(
 )
 @router.head("/details/date/{year}/{month}/{day}", include_in_schema=False)
 async def get_show_details_by_date(
-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12), day: conint(ge=1, le=31)
+    year: conint(ge=1998, le=9999),
+    month: conint(ge=1, le=12),
+    day: conint(ge=1, le=31),
 ):
     """Retrieve a Show object, based on year, month and day, containing:
     Show ID, date, Host, Scorekeeper, Panelists, Guests and other

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -8,10 +8,9 @@
 from datetime import date
 
 from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
 from mysql.connector.errors import DatabaseError, ProgrammingError
-from pydantic import conint, constr
 from wwdtm.show import Show
 from app.models.shows import (
     Show as ModelsShow,
@@ -66,7 +65,9 @@ async def get_shows():
     tags=["Shows"],
 )
 @router.head("/id/{show_id}", include_in_schema=False)
-async def get_show_by_id(show_id: conint(ge=0, lt=2**31)):
+async def get_show_by_id(
+    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
+):
     """Retrieve a Show object, based on Show ID, containing: Show ID,
     date and basic information."""
     try:
@@ -98,7 +99,9 @@ async def get_show_by_id(show_id: conint(ge=0, lt=2**31)):
     tags=["Shows"],
 )
 @router.head("/date/iso/{show_date}", include_in_schema=False)
-async def get_show_by_date_string(show_date: date):
+async def get_show_by_date_string(
+    show_date: Annotated[date, Path(title="ISO date for the show to get")]
+):
     """Retrieve a Show object, based on show date in ISO format
     (YYYY-MM-DD), containing: Show ID, date and basic information."""
     try:
@@ -132,7 +135,9 @@ async def get_show_by_date_string(show_date: date):
     tags=["Shows"],
 )
 @router.head("/date/{year}", include_in_schema=False)
-async def get_shows_by_year(year: conint(ge=1998, le=9999)):
+async def get_shows_by_year(
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
+):
     """Retrieve an array of Show objects, based on year, containing:
     Show ID, date and basic information.
 
@@ -169,7 +174,8 @@ async def get_shows_by_year(year: conint(ge=1998, le=9999)):
 )
 @router.head("/date/{year}/{month}", include_in_schema=False)
 async def get_shows_by_year_month(
-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12)
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
+    month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
 ):
     """Retrieve an array of Show objects, based on year and month,
     containing: Show ID, date and basic information.
@@ -203,12 +209,15 @@ async def get_shows_by_year_month(
 
 @router.get(
     "/date/month-day/{month}/{day}",
-    summary="Retrieve Information for a Show by Month and Day",
+    summary="Retrieve Information for Shows by Month and Day",
     response_model=ModelsShows,
     tags=["Shows"],
 )
 @router.head("/date/month-day/{month}/{day}", include_in_schema=False)
-async def get_show_by_month_day(month: conint(ge=1, le=12), day: conint(ge=1, le=31)):
+async def get_show_by_month_day(
+    month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
+    day: Annotated[int, Path(title="The day to get shows for", ge=1, le=31)],
+):
     """Retrieve a Show object, based on month and day, containing: Show
     ID, date and basic information."""
     try:
@@ -247,9 +256,9 @@ async def get_show_by_month_day(month: conint(ge=1, le=12), day: conint(ge=1, le
 )
 @router.head("/date/{year}/{month}/{day}", include_in_schema=False)
 async def get_show_by_date(
-    year: conint(ge=1998, le=9999),
-    month: conint(ge=1, le=12),
-    day: conint(ge=1, le=31),
+    year: Annotated[int, Path(title="The year to get a show for", ge=1998, le=9999)],
+    month: Annotated[int, Path(title="The month to get a show for", ge=1, le=12)],
+    day: Annotated[int, Path(title="The day to get a show for", ge=1, le=31)],
 ):
     """Retrieve a Show object, based on year, month and day, containing:
     Show ID, date and basic information."""
@@ -351,7 +360,9 @@ async def get_shows_details():
     tags=["Shows"],
 )
 @router.head("/details/date/iso/{show_date}", include_in_schema=False)
-async def get_show_details_by_date_string(show_date: date):
+async def get_show_details_by_date_string(
+    show_date: Annotated[date, Path(title="ISO date for the show to get")]
+):
     """Retrieve an array of Show objects, based on show date in ISO
     format (YYYY-MM-DD), containing: Show ID, date, Host, Scorekeeper,
     Panelists, Guests and other information."""
@@ -389,7 +400,9 @@ async def get_show_details_by_date_string(show_date: date):
     tags=["Shows"],
 )
 @router.head("/details/date/{year}", include_in_schema=False)
-async def get_shows_details_by_year(year: conint(ge=1998, le=9999)):
+async def get_shows_details_by_year(
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
+):
     """Retrieve an array of Show objects, based on year, containing:
     Show ID, date, Host, Scorekeeper, Panelists, Guests and other
     information.
@@ -429,8 +442,8 @@ async def get_shows_details_by_year(year: conint(ge=1998, le=9999)):
 )
 @router.head("/details/date/{year}/{month}", include_in_schema=False)
 async def get_shows_details_by_year_month(
-    year: conint(ge=1998, le=9999),
-    month: conint(ge=1, le=12),
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
+    month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
 ):
     """Retrieve an array of Show objects, based on year and month,
     containing: Show ID, date, Host, Scorekeeper, Panelists, Guests and
@@ -469,13 +482,14 @@ async def get_shows_details_by_year_month(
 
 @router.get(
     "/details/date/month-day/{month}/{day}",
-    summary="Retrieve Detailed Information for a Show by Month and Day",
+    summary="Retrieve Detailed Information for Shows by Month and Day",
     response_model=ModelsShowsDetails,
     tags=["Shows"],
 )
 @router.head("/details/date/month-day/{month}/{day}", include_in_schema=False)
 async def get_show_details_by_month_day(
-    month: conint(ge=1, le=12), day: conint(ge=1, le=31)
+    month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
+    day: Annotated[int, Path(title="The day to get shows for", ge=1, le=31)],
 ):
     """Retrieve a Show object, based on month and day, containing: Show
     ID, date, Host, Scorekeeper, Panelists, Guests and other information."""
@@ -517,9 +531,9 @@ async def get_show_details_by_month_day(
 )
 @router.head("/details/date/{year}/{month}/{day}", include_in_schema=False)
 async def get_show_details_by_date(
-    year: conint(ge=1998, le=9999),
-    month: conint(ge=1, le=12),
-    day: conint(ge=1, le=31),
+    year: Annotated[int, Path(title="The year to get a show for", ge=1998, le=9999)],
+    month: Annotated[int, Path(title="The month to get a show for", ge=1, le=12)],
+    day: Annotated[int, Path(title="The day to get a show for", ge=1, le=31)],
 ):
     """Retrieve a Show object, based on year, month and day, containing:
     Show ID, date, Host, Scorekeeper, Panelists, Guests and other
@@ -564,7 +578,9 @@ async def get_show_details_by_date(
     tags=["Shows"],
 )
 @router.head("/details/id/{show_id}", include_in_schema=False)
-async def get_show_details_by_id(show_id: conint(ge=0, lt=2**31)):
+async def get_show_details_by_id(
+    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
+):
     """Retrieve a Show object, based on Show ID, containing: Show ID,
     date, Host, Scorekeeper, Panelists, Guests and other information."""
     try:

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,673 @@
+[10:59:14] Start bump-pydantic.                                                                       main.py:60
+           Found 19 files to process                                                                  main.py:75
+
+
+--- app/models/guests.py
++++ app/models/guests.py
+@@ -6,13 +6,14 @@
+ """Guests Models"""
+ 
+ from typing import List, Optional, Union
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Guest(BaseModel):
+     """Not My Job Guest Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Guest ID")
++    id: Annotated = Field(title="Guest ID")
+     name: str = Field(title="Guest Name")
+     slug: Optional = Field(default=None, title="Guest Slug String")
+ 
+@@ -37,7 +38,7 @@
+ class GuestAppearance(BaseModel):
+     """Appearance Information"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    show_id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Repeat Show")
+--- app/models/hosts.py
++++ app/models/hosts.py
+@@ -6,13 +6,14 @@
+ """Hosts Models"""
+ 
+ from typing import List, Optional, Union
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Host(BaseModel):
+     """Host Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Host ID")
++    id: Annotated = Field(title="Host ID")
+     name: str = Field(title="Host Name")
+     slug: Optional = Field(default=None, title="Host Slug String")
+     gender: Optional = Field(default=None, title="Host Gender")
+@@ -38,7 +39,7 @@
+ class HostAppearance(BaseModel):
+     """Appearance Information"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    show_id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Repeat Show")
+--- app/models/scorekeepers.py
++++ app/models/scorekeepers.py
+@@ -6,13 +6,14 @@
+ """Scorekeepers Models"""
+ 
+ from typing import List, Optional, Union
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Scorekeeper(BaseModel):
+     """Scorekeeper Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Scorekeeper ID")
++    id: Annotated = Field(title="Scorekeeper ID")
+     name: str = Field(title="Scorekeeper Name")
+     slug: Optional = Field(default=None, title="Scorekeeper Slug String")
+     gender: Optional = Field(default=None, title="Scorekeeper Gender")
+@@ -38,7 +39,7 @@
+ class ScorekeeperAppearance(BaseModel):
+     """Appearance Information"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    show_id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Repeat Show")
+--- app/routers/hosts.py
++++ app/routers/hosts.py
+@@ -9,7 +9,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint, constr
++from pydantic import Field, StringConstraints
+ from wwdtm.host import Host
+ from app.models.hosts import (
+     Host as ModelsHost,
+@@ -17,6 +17,7 @@
+     HostDetails as ModelsHostDetails,
+     HostsDetails as ModelsHostsDetails,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
+ _config = load_config()
+@@ -62,7 +63,7 @@
+     tags=["Hosts"],
+ )
+ @router.head("/id/{host_id}", include_in_schema=False)
+-async def get_host_by_id(host_id: conint(ge=0, lt=2**31)):
++async def get_host_by_id(host_id: Annotated):
+     """Retrieve a Host object, based on Host ID, containing: Host ID,
+     name, slug string, and gender."""
+     try:
+@@ -93,7 +94,7 @@
+     tags=["Hosts"],
+ )
+ @router.head("/slug/{host_slug}", include_in_schema=False)
+-async def get_host_by_slug(host_slug: constr(strip_whitespace=True)):
++async def get_host_by_slug(host_slug: Annotated):
+     """Retrieve a Host object, based on Host slug string, containing:
+     Host ID, name, slug string, and gender."""
+     try:
+@@ -160,7 +161,7 @@
+     tags=["Hosts"],
+ )
+ @router.head("/details/id/{host_id}", include_in_schema=False)
+-async def get_host_details_by_id(host_id: conint(ge=0, lt=2**31)):
++async def get_host_details_by_id(host_id: Annotated):
+     """Retrieve a Host object, based on Host ID, containing: Host ID,
+     name, slug string, gender, and their appearance details.
+ 
+@@ -193,7 +194,7 @@
+     tags=["Hosts"],
+ )
+ @router.head("/details/slug/{host_slug}", include_in_schema=False)
+-async def get_host_details_by_slug(host_slug: constr(strip_whitespace=True)):
++async def get_host_details_by_slug(host_slug: Annotated):
+     """Retrieve a Host object, based on Host slug string, containing:
+     Host ID, name, slug string, gender, and their appearance details.
+ 
+--- app/routers/guests.py
++++ app/routers/guests.py
+@@ -9,7 +9,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint, constr
++from pydantic import Field, StringConstraints
+ from wwdtm.guest import Guest
+ from app.models.guests import (
+     Guest as ModelsGuest,
+@@ -17,6 +17,7 @@
+     GuestDetails as ModelsGuestDetails,
+     GuestsDetails as ModelsGuestsDetails,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/guests")
+ _config = load_config()
+@@ -62,7 +63,7 @@
+     tags=["Guests"],
+ )
+ @router.head("/id/{guest_id}", include_in_schema=False)
+-async def get_guest_by_id(guest_id: conint(ge=0, lt=2**31)):
++async def get_guest_by_id(guest_id: Annotated):
+     """Retrieve a Not My Job Guest object, based on Guest ID,
+     containing: Guest ID, name and slug string."""
+     try:
+@@ -95,7 +96,7 @@
+     tags=["Guests"],
+ )
+ @router.head("/slug/{guest_slug}", include_in_schema=False)
+-async def get_guest_by_slug(guest_slug: constr(strip_whitespace=True)):
++async def get_guest_by_slug(guest_slug: Annotated):
+     """Retrieve a Not My Job Guest object, based on Guest slug string,
+     containing: Guest ID, name and slug string."""
+     try:
+@@ -162,7 +163,7 @@
+     tags=["Guests"],
+ )
+ @router.head("/details/id/{guest_id}", include_in_schema=False)
+-async def get_guest_details_by_id(guest_id: conint(ge=0, lt=2**31)):
++async def get_guest_details_by_id(guest_id: Annotated):
+     """Retrieve a Not My Job Guest object, based on Guest ID,
+     containing: Guest ID, name, slug string, and their appearance details.
+ 
+@@ -197,7 +198,7 @@
+     tags=["Guests"],
+ )
+ @router.head("/details/slug/{guest_slug}", include_in_schema=False)
+-async def get_guest_details_by_slug(guest_slug: constr(strip_whitespace=True)):
++async def get_guest_details_by_slug(guest_slug: Annotated):
+     """Retrieve a Not My Job Guest object, based on Guest slug string,
+     containing: Guest ID, name, slug string, and their appearance details.
+ 
+--- app/routers/scorekeepers.py
++++ app/routers/scorekeepers.py
+@@ -9,7 +9,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint, constr
++from pydantic import Field, StringConstraints
+ from wwdtm.scorekeeper import Scorekeeper
+ from app.models.scorekeepers import (
+     Scorekeeper as ModelsScorekeeper,
+@@ -17,6 +17,7 @@
+     ScorekeeperDetails as ModelsScorekeeperDetails,
+     ScorekeepersDetails as ModelsScorekeepersDetails,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/scorekeepers")
+ _config = load_config()
+@@ -62,7 +63,7 @@
+     tags=["Scorekeepers"],
+ )
+ @router.head("/id/{scorekeeper_id}", include_in_schema=False)
+-async def get_scorekeeper_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
++async def get_scorekeeper_by_id(scorekeeper_id: Annotated):
+     """Retrieve a Scorekeeper object, based on Scorekeeper ID,
+     containing: Scorekeeper ID, name, slug string, and gender."""
+     try:
+@@ -97,7 +98,7 @@
+     tags=["Scorekeepers"],
+ )
+ @router.head("/slug/{scorekeeper_slug}", include_in_schema=False)
+-async def get_scorekeeper_by_slug(scorekeeper_slug: constr(strip_whitespace=True)):
++async def get_scorekeeper_by_slug(scorekeeper_slug: Annotated):
+     """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
+     containing: Scorekeeper ID, name, slug string, and gender."""
+     try:
+@@ -167,7 +168,7 @@
+     tags=["Scorekeepers"],
+ )
+ @router.head("/details/id/{scorekeeper_id}", include_in_schema=False)
+-async def get_scorekeeper_details_by_id(scorekeeper_id: conint(ge=0, lt=2**31)):
++async def get_scorekeeper_details_by_id(scorekeeper_id: Annotated):
+     """Retrieve a Scorekeeper object, based on Scorekeeper ID,
+     containing: Scorekeeper ID, name, slug string, gender, and their
+     appearance details.
+@@ -206,7 +207,7 @@
+ )
+ @router.head("/details/slug/{scorekeeper_slug}", include_in_schema=False)
+ async def get_scorekeeper_details_by_slug(
+-    scorekeeper_slug: constr(strip_whitespace=True),
++    scorekeeper_slug: Annotated,
+ ):
+     """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
+     containing: Scorekeeper ID, name, slug string, gender, and their
+--- app/models/locations.py
++++ app/models/locations.py
+@@ -6,13 +6,14 @@
+ """Locations Models"""
+ 
+ from typing import List, Optional
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Location(BaseModel):
+     """Location Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Location ID")
++    id: Annotated = Field(title="Location ID")
+     city: Optional = Field(default=None, title="City")
+     state: Optional = Field(default=None, title="State")
+     venue: Optional = Field(default=None, title="Venue Name")
+@@ -37,7 +38,7 @@
+ class LocationRecordingShow(BaseModel):
+     """Location Recording Information"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    show_id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Repeat Show")
+--- app/models/shows.py
++++ app/models/shows.py
+@@ -7,13 +7,14 @@
+ 
+ from decimal import Decimal
+ from typing import List, Optional, Union
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Show(BaseModel):
+     """Show Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Best Of Show")
+@@ -28,7 +29,7 @@
+ class ShowLocation(BaseModel):
+     """Show Location Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Location ID")
++    id: Annotated = Field(title="Location ID")
+     slug: Optional = Field(default=None, title="Location Slug String")
+     city: Optional = Field(default=None, title="City")
+     state: Optional = Field(default=None, title="State")
+@@ -38,7 +39,7 @@
+ class ShowHost(BaseModel):
+     """Show Host Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Host ID")
++    id: Annotated = Field(title="Host ID")
+     name: str = Field(title="Host Name")
+     slug: Optional = Field(default=None, title="Host Slug String")
+     guest: bool = Field(title="Guest Host")
+@@ -47,7 +48,7 @@
+ class ShowScorekeeper(BaseModel):
+     """Show Scorekeeper Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Scorekeeper ID")
++    id: Annotated = Field(title="Scorekeeper ID")
+     name: str = Field(title="Scorekeeper Name")
+     slug: Optional = Field(default=None, title="Scorekeeper Slug String")
+     guest: bool = Field(title="Guest Scorekeeper")
+@@ -57,7 +58,7 @@
+ class ShowPanelist(BaseModel):
+     """Show Panelist Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
++    id: Annotated = Field(title="Panelist ID")
+     name: str = Field(title="Panelist Name")
+     slug: Optional = Field(default=None, title="Panelist Slug String")
+     lightning_round_start: Union = Field(
+@@ -82,7 +83,7 @@
+ class ShowBluffPanelist(BaseModel):
+     """Show Bluff the Listener Panelist Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
++    id: Annotated = Field(title="Panelist ID")
+     name: str = Field(title="Panelist Name")
+     slug: Optional = Field(default=None, title="Panelist Slug String")
+ 
+@@ -101,7 +102,7 @@
+ class ShowGuest(BaseModel):
+     """Show Guest Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Guest ID")
++    id: Annotated = Field(title="Guest ID")
+     name: str = Field(title="Guest Name")
+     slug: Optional = Field(default=None, title="Guest Slug String")
+     score: Union = Field(default=None, title="Guest Score")
+--- app/routers/locations.py
++++ app/routers/locations.py
+@@ -9,7 +9,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint, constr
++from pydantic import Field, StringConstraints
+ from wwdtm.location import Location
+ from app.models.locations import (
+     Location as ModelsLocation,
+@@ -17,6 +17,7 @@
+     LocationDetails as ModelsLocationDetails,
+     LocationsDetails as ModelsLocationsDetails,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/locations")
+ _config = load_config()
+@@ -62,7 +63,7 @@
+     tags=["Locations"],
+ )
+ @router.head("/id/{location_id}", include_in_schema=False)
+-async def get_location_by_id(location_id: conint(ge=0, lt=2**31)):
++async def get_location_by_id(location_id: Annotated):
+     """Retrieve a Location object, based on Location ID, containing:
+     Location ID, city, state, venue, and slug string."""
+     try:
+@@ -97,7 +98,7 @@
+     tags=["Locations"],
+ )
+ @router.head("/slug/{location_slug}", include_in_schema=False)
+-async def get_location_by_slug(location_slug: constr(strip_whitespace=True)):
++async def get_location_by_slug(location_slug: Annotated):
+     """Retrieve a location object, based on Location slug string,
+     containing: Location ID, city, state, venue, and slug string."""
+     try:
+@@ -165,7 +166,7 @@
+     tags=["Locations"],
+ )
+ @router.head("/recordings/id/{location_id}", include_in_schema=False)
+-async def get_location_recordings_by_id(location_id: conint(ge=0, lt=2**31)):
++async def get_location_recordings_by_id(location_id: Annotated):
+     """Retrieve a Location object, based on Location ID, containing:
+     Location ID, city, state, venue, slug string, and an array of
+     recordings.
+@@ -203,7 +204,7 @@
+     tags=["Locations"],
+ )
+ @router.head("/recordings/slug/{location_slug}", include_in_schema=False)
+-async def get_location_recordings_by_slug(location_slug: constr(strip_whitespace=True)):
++async def get_location_recordings_by_slug(location_slug: Annotated):
+     """Retrieve a Location object, based on Location slug string,
+     containing: Location ID, city, state, venue, slug string, and an
+     array of recordings.
+--- app/models/panelists.py
++++ app/models/panelists.py
+@@ -7,13 +7,14 @@
+ 
+ from decimal import Decimal
+ from typing import List, Optional, Tuple, Union
+-from pydantic import BaseModel, conint, Field
++from pydantic import BaseModel, Field
++from typing_extensions import Annotated
+ 
+ 
+ class Panelist(BaseModel):
+     """Panelist Information"""
+ 
+-    id: conint(ge=0, lt=2**31) = Field(title="Panelist ID")
++    id: Annotated = Field(title="Panelist ID")
+     name: str = Field(title="Panelist Name")
+     slug: Optional = Field(default=None, title="Panelist Slug String")
+     gender: Optional = Field(default=None, title="Panelist Gender")
+@@ -104,14 +105,14 @@
+ class MilestonesFirst(BaseModel):
+     """Panelist First Appearance Milestone"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="First Show ID")
++    show_id: Annotated = Field(title="First Show ID")
+     show_date: str = Field(title="First Show Date")
+ 
+ 
+ class MilestonesMostRecent(BaseModel):
+     """Panelist Most Recent Appearance Milestone"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Most Recent Show ID")
++    show_id: Annotated = Field(title="Most Recent Show ID")
+     show_date: str = Field(title="Most Recent Show Date")
+ 
+ 
+@@ -135,7 +136,7 @@
+ class ShowAppearance(BaseModel):
+     """Panelist Show Appearance Information"""
+ 
+-    show_id: conint(ge=0, lt=2**31) = Field(title="Show ID")
++    show_id: Annotated = Field(title="Show ID")
+     date: str = Field(title="Show Date")
+     best_of: bool = Field(title="Best Of Show")
+     repeat_show: bool = Field(title="Repeat Show")
+--- app/routers/panelists.py
++++ app/routers/panelists.py
+@@ -9,7 +9,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint, constr
++from pydantic import Field, StringConstraints
+ from wwdtm.panelist import Panelist, PanelistDecimalScores, PanelistScores
+ from app.models.panelists import (
+     Panelist as ModelsPanelist,
+@@ -20,6 +20,7 @@
+     PanelistScoresOrderedPair as ModelsPanelistScoresOrderedPair,
+     PanelistScoresGroupedOrderedPair as ModelsPanelistScoresGroupedOrderedPair,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/panelists")
+ _config = load_config()
+@@ -65,7 +66,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/id/{panelist_id}", include_in_schema=False)
+-async def get_panelist_by_id(panelist_id: conint(ge=0, lt=2**31)):
++async def get_panelist_by_id(panelist_id: Annotated):
+     """Retrieve a Panelist object, based on Panelist ID, containing:
+     Panelist ID, name, slug string, and gender."""
+     try:
+@@ -100,7 +101,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/slug/{panelist_slug}", include_in_schema=False)
+-async def get_panelist_by_slug(panelist_slug: constr(strip_whitespace=True)):
++async def get_panelist_by_slug(panelist_slug: Annotated):
+     """Retrieve a Panelist object, based on Panelist slug string,
+     containing: Panelist ID, name, slug string, and gender."""
+     try:
+@@ -171,7 +172,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/details/id/{panelist_id}", include_in_schema=False)
+-async def get_panelist_details_by_id(panelist_id: conint(ge=0, lt=2**31)):
++async def get_panelist_details_by_id(panelist_id: Annotated):
+     """Retrieve a Panelist object, based on Panelist ID, containing:
+     Panelist ID, name, slug string, gender, and their statistics and
+     appearance details.
+@@ -211,7 +212,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/details/slug/{panelist_slug}", include_in_schema=False)
+-async def get_panelist_details_by_slug(panelist_slug: constr(strip_whitespace=True)):
++async def get_panelist_details_by_slug(panelist_slug: Annotated):
+     """Retrieve a Panelist object, based on Panelist slug string,
+     containing: Panelist ID, name, slug string, gender, and their
+     statistics and appearance details.
+@@ -252,7 +253,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/scores/id/{panelist_id}", include_in_schema=False)
+-async def get_panelist_scores_by_id(panelist_id: conint(ge=0, lt=2**31)):
++async def get_panelist_scores_by_id(panelist_id: Annotated):
+     """Retrieve Panelist scores, based on Panelist ID, as a pair of
+     lists, one list of show dates and one list of corresponding scores."""
+     try:
+@@ -296,7 +297,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/scores/slug/{panelist_slug}", include_in_schema=False)
+-async def get_panelist_scores_by_slug(panelist_slug: constr(strip_whitespace=True)):
++async def get_panelist_scores_by_slug(panelist_slug: Annotated):
+     """Retrieve Panelist scores, based on Panelist slug string, as a
+     pair of lists, one list of show dates and one list of corresponding
+     scores."""
+@@ -341,7 +342,7 @@
+ )
+ @router.head("/scores/grouped-ordered-pair/id/{panelist_id}", include_in_schema=False)
+ async def get_panelist_scores_grouped_ordered_pair_by_id(
+-    panelist_id: conint(ge=0, lt=2**31)
++    panelist_id: Annotated
+ ):
+     """Retrieve Panelist scores, based on Panelist ID, as grouped
+     ordered pairs, each pair containing a score and the corresponding
+@@ -394,7 +395,7 @@
+     "/scores/grouped-ordered-pair/slug/{panelist_slug}", include_in_schema=False
+ )
+ async def get_panelist_scores_grouped_ordered_pair_by_slug(
+-    panelist_slug: constr(strip_whitespace=True),
++    panelist_slug: Annotated,
+ ):
+     """Retrieve Panelist scores, based on Panelist slug string, as
+     grouped ordered pairs, each pair containing a score and the
+@@ -443,7 +444,7 @@
+     tags=["Panelists"],
+ )
+ @router.head("/scores/ordered-pair/id/{panelist_id}", include_in_schema=False)
+-async def get_panelist_scores_ordered_pair_by_id(panelist_id: conint(ge=0, lt=2**31)):
++async def get_panelist_scores_ordered_pair_by_id(panelist_id: Annotated):
+     """Retrieve Panelist scores, based on Panelist ID, as ordered
+     pairs, each pair containing the show date and the corresponding
+     score.
+@@ -488,7 +489,7 @@
+ )
+ @router.head("/scores/ordered-pair/slug/{panelist_slug}", include_in_schema=False)
+ async def get_panelist_scores_ordered_pair_by_slug(
+-    panelist_slug: constr(strip_whitespace=True),
++    panelist_slug: Annotated,
+ ):
+     """Retrieve Panelist scores, based on Panelist slug string, as
+     ordered pairs, each pair containing the show date and the
+--- app/routers/shows.py
++++ app/routers/shows.py
+@@ -11,7 +11,7 @@
+ from fastapi import APIRouter, HTTPException
+ import mysql.connector
+ from mysql.connector.errors import DatabaseError, ProgrammingError
+-from pydantic import conint
++from pydantic import Field
+ from wwdtm.show import Show
+ from app.models.shows import (
+     Show as ModelsShow,
+@@ -20,6 +20,7 @@
+     ShowDetails as ModelsShowDetails,
+     ShowsDetails as ModelsShowsDetails,
+ )
++from typing_extensions import Annotated
+ 
+ router = APIRouter(prefix=f"/v{API_VERSION}/shows")
+ _config = load_config()
+@@ -65,7 +66,7 @@
+     tags=["Shows"],
+ )
+ @router.head("/id/{show_id}", include_in_schema=False)
+-async def get_show_by_id(show_id: conint(ge=0, lt=2**31)):
++async def get_show_by_id(show_id: Annotated):
+     """Retrieve a Show object, based on Show ID, containing: Show ID,
+     date and basic information."""
+     try:
+@@ -131,7 +132,7 @@
+     tags=["Shows"],
+ )
+ @router.head("/date/{year}", include_in_schema=False)
+-async def get_shows_by_year(year: conint(ge=1998, le=9999)):
++async def get_shows_by_year(year: Annotated):
+     """Retrieve an array of Show objects, based on year, containing:
+     Show ID, date and basic information.
+ 
+@@ -168,7 +169,7 @@
+ )
+ @router.head("/date/{year}/{month}", include_in_schema=False)
+ async def get_shows_by_year_month(
+-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12)
++    year: Annotated, month: Annotated
+ ):
+     """Retrieve an array of Show objects, based on year and month,
+     containing: Show ID, date and basic information.
+@@ -207,7 +208,7 @@
+     tags=["Shows"],
+ )
+ @router.head("/date/month-day/{month}/{day}", include_in_schema=False)
+-async def get_show_by_month_day(month: conint(ge=1, le=12), day: conint(ge=1, le=31)):
++async def get_show_by_month_day(month: Annotated, day: Annotated):
+     """Retrieve a Show object, based on month and day, containing: Show
+     ID, date and basic information."""
+     try:
+@@ -246,7 +247,7 @@
+ )
+ @router.head("/date/{year}/{month}/{day}", include_in_schema=False)
+ async def get_show_by_date(
+-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12), day: conint(ge=1, le=31)
++    year: Annotated, month: Annotated, day: Annotated
+ ):
+     """Retrieve a Show object, based on year, month and day, containing:
+     Show ID, date and basic information."""
+@@ -386,7 +387,7 @@
+     tags=["Shows"],
+ )
+ @router.head("/details/date/{year}", include_in_schema=False)
+-async def get_shows_details_by_year(year: conint(ge=1998, le=9999)):
++async def get_shows_details_by_year(year: Annotated):
+     """Retrieve an array of Show objects, based on year, containing:
+     Show ID, date, Host, Scorekeeper, Panelists, Guests and other
+     information.
+@@ -426,7 +427,7 @@
+ )
+ @router.head("/details/date/{year}/{month}", include_in_schema=False)
+ async def get_shows_details_by_year_month(
+-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12)
++    year: Annotated, month: Annotated
+ ):
+     """Retrieve an array of Show objects, based on year and month,
+     containing: Show ID, date, Host, Scorekeeper, Panelists, Guests and
+@@ -471,7 +472,7 @@
+ )
+ @router.head("/details/date/month-day/{month}/{day}", include_in_schema=False)
+ async def get_show_details_by_month_day(
+-    month: conint(ge=1, le=12), day: conint(ge=1, le=31)
++    month: Annotated, day: Annotated
+ ):
+     """Retrieve a Show object, based on month and day, containing: Show
+     ID, date, Host, Scorekeeper, Panelists, Guests and other information."""
+@@ -513,7 +514,7 @@
+ )
+ @router.head("/details/date/{year}/{month}/{day}", include_in_schema=False)
+ async def get_show_details_by_date(
+-    year: conint(ge=1998, le=9999), month: conint(ge=1, le=12), day: conint(ge=1, le=31)
++    year: Annotated, month: Annotated, day: Annotated
+ ):
+     """Retrieve a Show object, based on year, month and day, containing:
+     Show ID, date, Host, Scorekeeper, Panelists, Guests and other
+@@ -558,7 +559,7 @@
+     tags=["Shows"],
+ )
+ @router.head("/details/id/{show_id}", include_in_schema=False)
+-async def get_show_details_by_id(show_id: conint(ge=0, lt=2**31)):
++async def get_show_details_by_id(show_id: Annotated):
+     """Retrieve a Show object, based on Show ID, containing: Show ID,
+     date, Host, Scorekeeper, Panelists, Guests and other information."""
+     try:
+[10:59:24] Run successfully!                                                                         main.py:152

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.4.0
+wwdtm==2.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pycodestyle==2.11.0
 pytest==7.4.0
 black==23.7.0
 
-pydantic==1.10.12
+pydantic<2
 fastapi==0.103.0
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.2.0
+wwdtm==2.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ pycodestyle==2.11.0
 pytest==7.4.0
 black==23.7.0
 
-pydantic<2
-fastapi==0.103.0
+pydantic==2.3.0
+fastapi==0.103.1
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0
 httpx==0.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==1.10.12
+pydantic<2
 fastapi==0.103.0
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.2.0
+wwdtm==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic==2.3.0
-fastapi==0.103.0
+fastapi==0.103.1
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0
 httpx==0.24.1
@@ -8,4 +8,4 @@ jinja2==3.1.2
 email-validator==2.0.0.post2
 requests==2.31.0
 
-wwdtm==2.4.0
+wwdtm==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic<2
+pydantic==2.3.0
 fastapi==0.103.0
 uvicorn[standard]==0.23.2
 gunicorn==21.2.0


### PR DESCRIPTION
- Migrate to Pydantic 2, which requires re-working of models, which includes:
  - Using [bump-pydantic](https://github.com/pydantic/bump-pydantic) to migrate to Pydantic 2
  - Replacing `conint` and `constr` with `Annotated[int, Path()]` and `Annotated[str, Path()]` respectively in routes
  - Replacing `strip_whitespace=True` to `string.strip()` when passing in values to a method
- Adding titles via `Path(title=)` to path elements in routes where applicable
- Correct spelling errors