### PR TITLE
Upgrade to wwdtm 2.5.0, support Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changes
 
+## 2.6.0
+
+**Starting with version 2.6.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+### Component Changes
+
+- Upgrade wwdtm from 2.4.1 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
+  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+  - Upgrade numpy from 1.24.4 to 1.26.0
+- Upgrade pydantic from 2.3.0 to 2.5.2
+- Upgrade fastapi from 0.103.1 to 0.104.1
+- Upgrade uvicorn from 0.23.2 to 0.24.0.post1
+- Upgrade httpx from 0.24.1 to 0.25.2
+- Upgrade email-validator from 2.0.0.post2 to 2.1.0.post1
+
+### Development Changes
+
+- Upgrade pytest from 7.4.0 to 7.4.3
+- Upgrade black from 23.7.0 to 23.11.0
+- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
+- Bump minimum pytest version from 7.0 to 7.4 in `pyproject.toml`
+
 ## 2.5.0
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.5.0"
+APP_VERSION = "2.6.0"
 
 
 def load_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.black]
-required-version = "23.7.0"
-target-version = ["py38", "py39", "py310", "py311"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,16 @@
 flake8==6.1.0
 pycodestyle==2.11.0
-pytest==7.4.0
-black==23.7.0
+pytest==7.4.3
+black==23.11.0
 
-pydantic==2.3.0
-fastapi==0.103.1
-uvicorn[standard]==0.23.2
+pydantic==2.5.2
+fastapi==0.104.1
+uvicorn[standard]==0.24.0.post1
 gunicorn==21.2.0
-httpx==0.24.1
+httpx==0.25.2
 aiofiles==23.2.1
 jinja2==3.1.2
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.4.1
+wwdtm==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pydantic==2.3.0
-fastapi==0.103.1
-uvicorn[standard]==0.23.2
+pydantic==2.5.2
+fastapi==0.104.1
+uvicorn[standard]==0.24.0.post1
 gunicorn==21.2.0
-httpx==0.24.1
+httpx==0.25.2
 aiofiles==23.2.1
 jinja2==3.1.2
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.4.1
+wwdtm==2.5.0


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.4.1 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
  - Upgrade numpy from 1.24.4 to 1.26.0
- Upgrade pydantic from 2.3.0 to 2.5.2
- Upgrade fastapi from 0.103.1 to 0.104.1
- Upgrade uvicorn from 0.23.2 to 0.24.0.post1
- Upgrade httpx from 0.24.1 to 0.25.2
- Upgrade email-validator from 2.0.0.post2 to 2.1.0.post1

## Development Changes

- Upgrade pytest from 7.4.0 to 7.4.3
- Upgrade black from 23.7.0 to 23.11.0
- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
- Bump minimum pytest version from 7.0 to 7.4 in `pyproject.toml`