### PR TITLE
Add support for shows with multiple Bluff segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2.7.0
+
+### Application Changes
+
+- Add support for shows that have multiple Bluff the Listener-like segments.
+- This changes includes renaming the `bluff` key returned in show details objects to `bluffs`. The new `bluffs` key now returns an array of objects that includes a `segment` key used to denote which segment it is referencing, along with the `chosen_panelist` and `correct_panelist` objects.
+
+### Component Changes
+
+- Upgrade wwdtm from 2.5.0 to 2.6.0, which requires Wait Wait Stats Database version 4.4 or higher
+
 ## 2.6.0
 
 **Starting with version 2.6.0, support for all versions of Python prior to 3.10 have been deprecated.**

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.6.0"
+APP_VERSION = "2.7.0"
 
 
 def load_config(

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -91,6 +91,7 @@ class ShowBluffPanelist(BaseModel):
 class ShowBluffDetails(BaseModel):
     """Show Bluff the Listener Chosen and Correct Panelists"""
 
+    segment: int = Field(title="Bluff Segment Number")
     chosen_panelist: Optional[ShowBluffPanelist] = Field(
         default=None, title="Chosen Panelist"
     )
@@ -125,7 +126,7 @@ class ShowDetails(Show):
     panelists: Optional[List[ShowPanelist]] = Field(
         default=None, title="Show Panelists"
     )
-    bluff: Optional[ShowBluffDetails] = Field(
+    bluffs: Optional[List[ShowBluffDetails]] = Field(
         default=None, title="Bluff the Listener Information"
     )
     guests: Optional[List[ShowGuest]] = Field(default=None, title="Show Guests")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,4 @@ jinja2==3.1.2
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.5.0
+wwdtm==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.2
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.5.0
+wwdtm==2.6.0


### PR DESCRIPTION
## Application Changes

- Add support for shows that have multiple Bluff the Listener-like segments.
- This changes includes renaming the `bluff` key returned in show details objects to `bluffs`. The new `bluffs` key now returns an array of objects that includes a `segment` key used to denote which segment it is referencing, along with the `chosen_panelist` and `correct_panelist` objects.

## Component Changes

- Upgrade wwdtm from 2.5.0 to 2.6.0, which requires Wait Wait Stats Database version 4.4 or higher