### PR TITLE
Ruff, code cleanup, docstring updates and adding show URL field to show objects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "python.linting.pylintArgs": [
-        "--extension-pkg-whitelist=numpy,mysql,slugify,wwdtm"
-    ],
     "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "black",
+    "[python]": {
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit",
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.7.2
+
+### Component Changes
+
+- Upgrade jinja2 from 3.1.2 to 3.1.3
+
 ## 2.7.1
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changes
 
+## 2.8.0
+
+### Application Changes
+
+- Starting with application version 2.8.0 of the Stats API, the minimum required version of the Wait Wait Stats Database is 4.5
+- Add support for returning show URL value from the Wait Wait Stats Database as `show_url` in returned show objects
+- Code cleanup and updating docstrings
+
+### Component Changes
+
+- Upgrade wwdtm from 2.6.1 to 2.8.0
+- Upgrade pydantic from 2.5.2 to 2.5.3
+- Upgrade fastapi from 0.104.1 to 0.109.0
+- Upgrade uvicorn from 0.24.0.post1 to 0.26.0
+- Upgrade httpx from 0.25.2 to 0.26.0
+
+### Development Changes
+
+- Switch to Ruff for code linting and formatting (with the help of Black)
+- Upgrade black from 23.11.0 to 23.12.1
+- Upgrade pytest from 7.4.3 from 7.4.4
+
 ## 2.7.2
 
 ### Component Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""FastAPI application __init__.py for api.wwdt.me"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""FastAPI application __init__.py for api.wwdt.me."""

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict
 
 API_VERSION = "2.0"
-APP_VERSION = "2.7.1"
+APP_VERSION = "2.7.2"
 
 
 def load_config(

--- a/app/config.py
+++ b/app/config.py
@@ -1,24 +1,24 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Application Configuration"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Application Configuration."""
 
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.7.2"
+APP_VERSION = "2.8.0"
 
 
 def load_config(
     config_file_path: str = "config.json",
     connection_pool_size: int = 10,
     connection_pool_name: str = "wwdtm_api",
-) -> Dict[str, Any]:
-    """Reads in database configuration values from a configuration
-    JSON file and returns a dictionary with the values.
+) -> dict[str, Any]:
+    """Reads application and database settings from JSON file.
 
     :param config_file: Path to the configuration JSON file
     :type config_file: str, optional
@@ -28,7 +28,8 @@ def load_config(
     :return: Dictionary containing database configuration settings
     :rtype: Dict[str, Any]
     """
-    with open(config_file_path, "r") as config_file:
+    _config_file_path = Path(config_file_path)
+    with _config_file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
 
     settings_config = config_dict.get("settings", None)

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""FastAPI main application for api.wwdt.me"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""FastAPI main application for api.wwdt.me."""
 
-from os.path import exists
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
@@ -50,32 +50,39 @@ config = load_config()
 @app.get("/", include_in_schema=False, response_class=HTMLResponse)
 @app.head("/", include_in_schema=False, response_class=HTMLResponse)
 async def default_page(request: Request):
+    """Route: Landing Page."""
     if "settings" in config and config["settings"]:
         settings = config["settings"]
-        stats_url = settings.get("stats_url", None)
+        stats_url: str | None = settings.get("stats_url", None)
+        patreon_url: str | None = settings.get("patreon_url", None)
     else:
         stats_url = None
     return templates.TemplateResponse(
-        "index.html", {"request": request, "stats_url": stats_url}
+        "index.html",
+        {"request": request, "stats_url": stats_url, "patreon_url": patreon_url},
     )
 
 
 @app.get("/favicon.ico", include_in_schema=False, response_class=RedirectResponse)
 @app.head("/favicon.ico", include_in_schema=False, response_class=RedirectResponse)
 async def favicon():
+    """Route: favicon.ico."""
     return RedirectResponse("/static/favicon.ico", status_code=301)
 
 
 @app.get("/robots.txt", include_in_schema=False)
 @app.head("/robots.txt", include_in_schema=False)
 async def robots_txt():
-    """Attempts to serve up static/robots.txt or
-    static/robots.txt.dist to the requester. Raise a 404 error if
-    neither file are found.
+    """Route: robots.txt.
+
+    Attempts to serve up static/robots.txt or static/robots.txt.dist to
+    the requester. Raise a 404 error if neither file are found.
     """
-    if exists("static/robots.txt"):
+    robots_txt_path = Path.cwd() / "static" / "robots.txt"
+    robots_txt_dist_path = Path.cwd() / "static" / "robots.txt.dist"
+    if robots_txt_path.exists():
         return FileResponse(path="static/robots.txt", media_type="text/plain")
-    elif exists("static/robots.txt.dist"):
+    elif robots_txt_dist_path.exists():
         return FileResponse(path="static/robots.txt.dist", media_type="text/plain")
     else:
         raise HTTPException(status_code=404)
@@ -84,12 +91,14 @@ async def robots_txt():
 @app.get("/docs", include_in_schema=False, response_class=RedirectResponse)
 @app.head("/docs", include_in_schema=False, response_class=RedirectResponse)
 async def redoc_redirect_docs():
+    """Route: Redirect /docs to specific docs path."""
     return RedirectResponse(f"/v{API_VERSION}/docs", status_code=301)
 
 
 @app.get("/redoc", include_in_schema=False, response_class=RedirectResponse)
 @app.head("/redoc", include_in_schema=False, response_class=RedirectResponse)
 async def redoc_redirect_redoc():
+    """Route: Redirect /redoc to specific docs path."""
     return RedirectResponse(f"/v{API_VERSION}/docs", status_code=301)
 
 
@@ -100,18 +109,21 @@ async def redoc_redirect_redoc():
     f"/v{API_VERSION}/redoc", include_in_schema=False, response_class=RedirectResponse
 )
 async def redoc_redirect_sub():
+    """Route: Redirect for /docs."""
     return RedirectResponse(f"/v{API_VERSION}/docs", status_code=301)
 
 
 @app.get("/v1.0", include_in_schema=False, response_class=RedirectResponse)
 @app.head("/v1.0", include_in_schema=False, response_class=RedirectResponse)
 async def api_v1_redirect():
+    """Route: Redirect /v1.0 to Landing Page."""
     return RedirectResponse("/", status_code=301)
 
 
 @app.get("/v1.0/docs", include_in_schema=False, response_class=RedirectResponse)
 @app.head("/v1.0/docs", include_in_schema=False, response_class=RedirectResponse)
 async def api_v1_docs_redirect():
+    """Route: Redirect /v1.0/docs to Landing Page."""
     return RedirectResponse("/", status_code=301)
 
 

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""FastAPI Metadata for api.wwdt.me"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""FastAPI Metadata for api.wwdt.me."""
+
+from email_validator import EmailNotValidError, validate_email
 
 from app.config import load_config
-from email_validator import validate_email, EmailNotValidError
-
 
 _config = load_config()
 _contact_info = {}

--- a/app/models/guests.py
+++ b/app/models/guests.py
@@ -1,71 +1,68 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Guests Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Guests Models."""
 
-from typing import List, Optional, Union
+from typing import Annotated
+
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 
 class Guest(BaseModel):
-    """Not My Job Guest Information"""
+    """Not My Job Guest Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Guest ID")
     name: str = Field(title="Guest Name")
-    slug: Optional[str] = Field(default=None, title="Guest Slug String")
+    slug: str | None = Field(default=None, title="Guest Slug String")
 
 
 class Guests(BaseModel):
-    """List of Not My Job Guests"""
+    """List of Not My Job Guests."""
 
-    guests: List[Guest] = Field(title="List of Guests")
+    guests: list[Guest] = Field(title="List of Guests")
 
 
 class GuestAppearanceCounts(BaseModel):
-    """Count of Show Appearances"""
+    """Count of Show Appearances."""
 
-    regular_shows: Optional[int] = Field(
+    regular_shows: int | None = Field(
         default=None, title="Count of Regular Show Appearances"
     )
-    all_shows: Optional[int] = Field(
-        default=None, title="Count of All Show Appearances"
-    )
+    all_shows: int | None = Field(default=None, title="Count of All Show Appearances")
 
 
 class GuestAppearance(BaseModel):
-    """Appearance Information"""
+    """Appearance Information."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")
-    score: Optional[int] = Field(default=None, title="Guest Score")
-    score_exception: Optional[bool] = Field(
-        default=None, title="Guest Scoring Exception"
-    )
+    score: int | None = Field(default=None, title="Guest Score")
+    score_exception: bool | None = Field(default=None, title="Guest Scoring Exception")
 
 
 class GuestAppearances(BaseModel):
-    """Not My Job Guest Appearances Information"""
+    """Not My Job Guest Appearances Information."""
 
-    count: Union[GuestAppearanceCounts, int] = Field(title="Count of Show Appearances")
-    shows: Optional[List[GuestAppearance]] = Field(
+    count: GuestAppearanceCounts | int = Field(title="Count of Show Appearances")
+    shows: list[GuestAppearance] | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class GuestDetails(Guest):
-    """Not My Job Guest Information with Appearances"""
+    """Not My Job Guest Information with Appearances."""
 
-    appearances: Optional[GuestAppearances] = Field(
+    appearances: GuestAppearances | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class GuestsDetails(BaseModel):
-    """List of Not My Job Guest Details"""
+    """List of Not My Job Guest Details."""
 
-    guests: List[GuestDetails] = Field(title="List of Guest Details")
+    guests: list[GuestDetails] = Field(title="List of Guest Details")
+    guests: list[GuestDetails] = Field(title="List of Guest Details")

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -1,43 +1,41 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Hosts Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Hosts Models."""
 
-from typing import List, Optional, Union
+from typing import Annotated
+
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 
 class Host(BaseModel):
-    """Host Information"""
+    """Host Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Host ID")
     name: str = Field(title="Host Name")
-    slug: Optional[str] = Field(default=None, title="Host Slug String")
-    gender: Optional[str] = Field(default=None, title="Host Gender")
+    slug: str | None = Field(default=None, title="Host Slug String")
+    gender: str | None = Field(default=None, title="Host Gender")
 
 
 class Hosts(BaseModel):
-    """List of Hosts"""
+    """List of Hosts."""
 
-    hosts: List[Host] = Field(title="List of Hosts")
+    hosts: list[Host] = Field(title="List of Hosts")
 
 
 class HostAppearanceCounts(BaseModel):
-    """Count of Show Appearances"""
+    """Count of Show Appearances."""
 
-    regular_shows: Optional[int] = Field(
+    regular_shows: int | None = Field(
         default=None, title="Count of Regular Show Appearances"
     )
-    all_shows: Optional[int] = Field(
-        default=None, title="Count of All Show Appearances"
-    )
+    all_shows: int | None = Field(default=None, title="Count of All Show Appearances")
 
 
 class HostAppearance(BaseModel):
-    """Appearance Information"""
+    """Appearance Information."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
@@ -47,23 +45,24 @@ class HostAppearance(BaseModel):
 
 
 class HostAppearances(BaseModel):
-    """Host Appearance Information"""
+    """Host Appearance Information."""
 
-    count: Union[HostAppearanceCounts, int] = Field(title="Count of Show Appearances")
-    shows: Optional[List[HostAppearance]] = Field(
+    count: HostAppearanceCounts | int = Field(title="Count of Show Appearances")
+    shows: list[HostAppearance] | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class HostDetails(Host):
-    """Host Information with Appearances"""
+    """Host Information with Appearances."""
 
-    appearances: Optional[HostAppearances] = Field(
+    appearances: HostAppearances | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class HostsDetails(BaseModel):
-    """List of Host Details"""
+    """List of Host Details."""
 
-    hosts: List[HostDetails] = Field(title="List of Host Details")
+    hosts: list[HostDetails] = Field(title="List of Host Details")
+    hosts: list[HostDetails] = Field(title="List of Host Details")

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -1,42 +1,42 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Locations Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Locations Models."""
 
-from typing import List, Optional
+from typing import Annotated
+
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 
 class Location(BaseModel):
-    """Location Information"""
+    """Location Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Location ID")
-    city: Optional[str] = Field(default=None, title="City")
-    state: Optional[str] = Field(default=None, title="State")
-    venue: Optional[str] = Field(default=None, title="Venue Name")
-    slug: Optional[str] = Field(default=None, title="Location Slug String")
+    city: str | None = Field(default=None, title="City")
+    state: str | None = Field(default=None, title="State")
+    venue: str | None = Field(default=None, title="Venue Name")
+    slug: str | None = Field(default=None, title="Location Slug String")
 
 
 class Locations(BaseModel):
-    """List of Locations"""
+    """List of Locations."""
 
-    locations: List[Location] = Field(title="List of Locations")
+    locations: list[Location] = Field(title="List of Locations")
 
 
 class LocationRecordingCounts(BaseModel):
-    """Count of Recordings for a Location"""
+    """Count of Recordings for a Location."""
 
-    regular_shows: Optional[int] = Field(
+    regular_shows: int | None = Field(
         default=None, title="Count of Regular Show Recordings"
     )
-    all_shows: Optional[int] = Field(default=None, title="Count of All Show Recordings")
+    all_shows: int | None = Field(default=None, title="Count of All Show Recordings")
 
 
 class LocationRecordingShow(BaseModel):
-    """Location Recording Information"""
+    """Location Recording Information."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
@@ -45,25 +45,26 @@ class LocationRecordingShow(BaseModel):
 
 
 class LocationRecordings(BaseModel):
-    """Location Information and Recordings"""
+    """Location Information and Recordings."""
 
-    count: Optional[LocationRecordingCounts] = Field(
+    count: LocationRecordingCounts | None = Field(
         default=None, title="Count of Show Recordings"
     )
-    shows: Optional[List[LocationRecordingShow]] = Field(
+    shows: list[LocationRecordingShow] | None = Field(
         default=None, title="List of Show Recordings"
     )
 
 
 class LocationDetails(Location):
-    """Location Information with Recordings"""
+    """Location Information with Recordings."""
 
-    recordings: Optional[LocationRecordings] = Field(
+    recordings: LocationRecordings | None = Field(
         default=None, title="List of Show Recordings"
     )
 
 
 class LocationsDetails(BaseModel):
-    """List of Location Details"""
+    """List of Location Details."""
 
-    locations: List[LocationDetails] = Field(title="List of Location Details")
+    locations: list[LocationDetails] = Field(title="List of Location Details")
+    locations: list[LocationDetails] = Field(title="List of Location Details")

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -1,33 +1,33 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Panelists Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Panelists Models."""
 
 from decimal import Decimal
-from typing import List, Optional, Tuple, Union
+from typing import Annotated
+
 from pydantic import BaseModel, Field, RootModel
-from typing_extensions import Annotated
 
 
 class Panelist(BaseModel):
-    """Panelist Information"""
+    """Panelist Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
-    slug: Optional[str] = Field(default=None, title="Panelist Slug String")
-    gender: Optional[str] = Field(default=None, title="Panelist Gender")
+    slug: str | None = Field(default=None, title="Panelist Slug String")
+    gender: str | None = Field(default=None, title="Panelist Gender")
 
 
 class Panelists(BaseModel):
-    """List of Panelists"""
+    """List of Panelists."""
 
-    panelists: List[Panelist] = Field(title="List of Panelists")
+    panelists: list[Panelist] = Field(title="List of Panelists")
 
 
 class ScoringStatistics(BaseModel):
-    """Scoring Statistics"""
+    """Scoring Statistics."""
 
     minimum: int = Field(title="Minimum Score")
     maximum: int = Field(title="Maximum Score")
@@ -38,7 +38,7 @@ class ScoringStatistics(BaseModel):
 
 
 class DecimalScoringStatistics(BaseModel):
-    """Scoring Statistics"""
+    """Scoring Statistics."""
 
     minimum: Decimal = Field(title="Minimum Score")
     maximum: Decimal = Field(title="Maximum Score")
@@ -49,7 +49,7 @@ class DecimalScoringStatistics(BaseModel):
 
 
 class RankingCounts(BaseModel):
-    """Ranking Counts"""
+    """Ranking Counts."""
 
     first: int = Field(title="Count of Ranking First")
     first_tied: int = Field(title="Count of Ranking Tied for First")
@@ -59,7 +59,7 @@ class RankingCounts(BaseModel):
 
 
 class RankingPercentages(BaseModel):
-    """Ranking Percentages"""
+    """Ranking Percentages."""
 
     first: float = Field(title="Percentage of Ranking First")
     first_tied: float = Field(title="Percentage of Ranking Tied for First")
@@ -69,48 +69,42 @@ class RankingPercentages(BaseModel):
 
 
 class PanelistRankings(BaseModel):
-    """Panelist Ranking Statistics"""
+    """Panelist Ranking Statistics."""
 
-    rank: Optional[RankingCounts] = Field(default=None, title="Ranking Counts")
-    percentage: Optional[RankingPercentages] = Field(
+    rank: RankingCounts | None = Field(default=None, title="Ranking Counts")
+    percentage: RankingPercentages | None = Field(
         default=None, title="Ranking Percentages"
     )
 
 
 class PanelistStatistics(BaseModel):
-    """Panelist Scoring and Ranking Statistics"""
+    """Panelist Scoring and Ranking Statistics."""
 
-    scoring: Optional[ScoringStatistics] = Field(
-        default=None, title="Scoring Statistics"
-    )
-    scoring_decimal: Optional[DecimalScoringStatistics] = Field(
+    scoring: ScoringStatistics | None = Field(default=None, title="Scoring Statistics")
+    scoring_decimal: DecimalScoringStatistics | None = Field(
         default=None, title="Decimal Scoring Statistics"
     )
-    ranking: Optional[PanelistRankings] = Field(
-        default=None, title="Ranking Percentages"
-    )
+    ranking: PanelistRankings | None = Field(default=None, title="Ranking Percentages")
 
 
 class PanelistBluffs(BaseModel):
-    """Panelist Bluff the Listener Statistics"""
+    """Panelist Bluff the Listener Statistics."""
 
-    chosen: Optional[int] = Field(
-        default=None, title="Chosen Bluff the Listener Stories"
-    )
-    correct: Optional[int] = Field(
+    chosen: int | None = Field(default=None, title="Chosen Bluff the Listener Stories")
+    correct: int | None = Field(
         default=None, title="Correct Bluff the Listener Stories"
     )
 
 
 class MilestonesFirst(BaseModel):
-    """Panelist First Appearance Milestone"""
+    """Panelist First Appearance Milestone."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="First Show ID")
     show_date: str = Field(title="First Show Date")
 
 
 class MilestonesMostRecent(BaseModel):
-    """Panelist Most Recent Appearance Milestone"""
+    """Panelist Most Recent Appearance Milestone."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(
         title="Most Recent Show ID"
@@ -119,16 +113,16 @@ class MilestonesMostRecent(BaseModel):
 
 
 class AppearanceMilestones(BaseModel):
-    """Panelist Appearance Milestones"""
+    """Panelist Appearance Milestones."""
 
-    first: Optional[MilestonesFirst] = Field(default=None, title="First Appearance")
-    most_recent: Optional[MilestonesMostRecent] = Field(
+    first: MilestonesFirst | None = Field(default=None, title="First Appearance")
+    most_recent: MilestonesMostRecent | None = Field(
         default=None, title="Most Recent Appearance"
     )
 
 
 class AppearanceCounts(BaseModel):
-    """Panelist Appearance Counts"""
+    """Panelist Appearance Counts."""
 
     regular_shows: int = Field(title="Regular Show Appearances")
     all_shows: int = Field(title="All Show Appearances")
@@ -136,104 +130,100 @@ class AppearanceCounts(BaseModel):
 
 
 class ShowAppearance(BaseModel):
-    """Panelist Show Appearance Information"""
+    """Panelist Show Appearance Information."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")
-    lightning_round_start: Optional[int] = Field(
+    lightning_round_start: int | None = Field(
         default=None, title="Lightning Round Starting Score"
     )
-    lightning_round_start_decimal: Optional[Decimal] = Field(
+    lightning_round_start_decimal: Decimal | None = Field(
         default=None, title="Lightning Round Starting Decimal Score"
     )
-    lightning_round_correct: Optional[int] = Field(
+    lightning_round_correct: int | None = Field(
         default=None, title="Lightning Round Correct Answers"
     )
-    lightning_round_correct_decimal: Optional[Decimal] = Field(
+    lightning_round_correct_decimal: Decimal | None = Field(
         default=None, title="Lightning Round Correct Answers (Decimal)"
     )
-    score: Optional[int] = Field(default=None, title="Total Score")
-    score_decimal: Optional[Decimal] = Field(default=None, title="Total Decimal Score")
-    rank: Optional[str] = Field(default=None, title="Ranking Position")
+    score: int | None = Field(default=None, title="Total Score")
+    score_decimal: Decimal | None = Field(default=None, title="Total Decimal Score")
+    rank: str | None = Field(default=None, title="Ranking Position")
 
 
 class PanelistAppearances(BaseModel):
-    """List of Panelist Show Appearances"""
+    """List of Panelist Show Appearances."""
 
-    milestones: Optional[AppearanceMilestones] = Field(
+    milestones: AppearanceMilestones | None = Field(
         default=None, title="Panelist Appearance Milestones"
     )
-    count: Optional[AppearanceCounts] = Field(
+    count: AppearanceCounts | None = Field(
         default=None, title="Panelist Appearance Counts"
     )
-    shows: Optional[List[ShowAppearance]] = Field(
+    shows: list[ShowAppearance] | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class PanelistDetails(Panelist):
-    """Panelist Information, Statistics and Appearances"""
+    """Panelist Information, Statistics and Appearances."""
 
-    statistics: Optional[PanelistStatistics] = Field(
+    statistics: PanelistStatistics | None = Field(
         default=None, title="Panelist Statistics"
     )
-    bluffs: Optional[PanelistBluffs] = Field(
+    bluffs: PanelistBluffs | None = Field(
         default=None, title="Panelist Bluff the Listener Statistics"
     )
-    appearances: Optional[PanelistAppearances] = Field(
+    appearances: PanelistAppearances | None = Field(
         default=None, title="List of Panelist Appearances"
     )
 
 
 class PanelistsDetails(BaseModel):
-    """List of Panelists's Information, Statistics and Appearances"""
+    """List of Panelists's Information, Statistics and Appearances."""
 
-    panelists: Optional[List[PanelistDetails]] = Field(
+    panelists: list[PanelistDetails] | None = Field(
         default=None, title="List of Panelist Details"
     )
 
 
 class PanelistScoresList(BaseModel):
-    """Object containing a list of Panelist Appearances as Show Dates
-    and a list of corresponding Panelist scores"""
+    """List of Panelist Appearances as Show Dates and a list of corresponding Panelist scores."""
 
-    shows: Optional[List[str]] = Field(
+    shows: list[str] | None = Field(
         default=None, title="List of Panelist Appearances as Show Dates"
     )
-    scores: Optional[List[Union[Decimal, int]]] = Field(
+    scores: list[Decimal | int] | None = Field(
         default=None, title="List of Panelist Scores"
     )
 
 
-class ScoresOrderedPair(RootModel[Tuple]):
-    """Tuple containing a show date and the corresponding score"""
+class ScoresOrderedPair(RootModel[tuple]):
+    """Tuple containing a show date and the corresponding score."""
 
     pass
 
 
 class PanelistScoresOrderedPair(BaseModel):
-    """Tuple containing Panelist appearance as Show Date and their
-    score for that show"""
+    """Tuple containing Panelist appearance as Show Date and score each show."""
 
-    scores: Optional[List[ScoresOrderedPair]] = Field(
-        default=None, title="List of Ordered Pairs containing " "Show Date and Score"
+    scores: list[ScoresOrderedPair] | None = Field(
+        default=None, title="List of Ordered Pairs containing Show Date and Score"
     )
 
 
-class ScoresGroupedOrderedPair(RootModel[Tuple]):
-    """Tuple containing a score and their corresponding number of times
-    that score had been earned"""
+class ScoresGroupedOrderedPair(RootModel[tuple]):
+    """Tuple containing a score and the occurrences of that score."""
 
     pass
 
 
 class PanelistScoresGroupedOrderedPair(BaseModel):
-    """Tuple containing scores and the corresponding number of times a
-    that score had been earned"""
+    """List of tuples containing a score and the occurrences of that score."""
 
-    scores: Optional[List[ScoresGroupedOrderedPair]] = Field(
+    scores: list[ScoresGroupedOrderedPair] | None = Field(
         default=None,
         title="List of Ordered Pairs"
         "containing scores and "

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -1,72 +1,69 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Scorekeepers Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Scorekeepers Models."""
 
-from typing import List, Optional, Union
+from typing import Annotated
+
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 
 class Scorekeeper(BaseModel):
-    """Scorekeeper Information"""
+    """Scorekeeper Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Scorekeeper ID")
     name: str = Field(title="Scorekeeper Name")
-    slug: Optional[str] = Field(default=None, title="Scorekeeper Slug String")
-    gender: Optional[str] = Field(default=None, title="Scorekeeper Gender")
+    slug: str | None = Field(default=None, title="Scorekeeper Slug String")
+    gender: str | None = Field(default=None, title="Scorekeeper Gender")
 
 
 class Scorekeepers(BaseModel):
-    """List of Scorekeepers"""
+    """List of Scorekeepers."""
 
-    scorekeepers: List[Scorekeeper] = Field(title="List of Scorekeepers")
+    scorekeepers: list[Scorekeeper] = Field(title="List of Scorekeepers")
 
 
 class ScorekeeperAppearanceCounts(BaseModel):
-    """Count of Show Appearances"""
+    """Count of Show Appearances."""
 
-    regular_shows: Optional[int] = Field(
+    regular_shows: int | None = Field(
         default=None, title="Count of Regular Show Appearances"
     )
-    all_shows: Optional[int] = Field(
-        default=None, title="Count of All Show Appearances"
-    )
+    all_shows: int | None = Field(default=None, title="Count of All Show Appearances")
 
 
 class ScorekeeperAppearance(BaseModel):
-    """Appearance Information"""
+    """Appearance Information."""
 
     show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")
     guest: bool = Field(title="Guest Scorekeeper")
-    description: Optional[str] = Field(default=None, title="Scorekeeper Introduction")
+    description: str | None = Field(default=None, title="Scorekeeper Introduction")
 
 
 class ScorekeeperAppearances(BaseModel):
-    """Scorekeeper Appearance Information"""
+    """Scorekeeper Appearance Information."""
 
-    count: Union[ScorekeeperAppearanceCounts, int] = Field(
-        title="Count of Show Appearances"
-    )
-    shows: Optional[List[ScorekeeperAppearance]] = Field(
+    count: ScorekeeperAppearanceCounts | int = Field(title="Count of Show Appearances")
+    shows: list[ScorekeeperAppearance] | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class ScorekeeperDetails(Scorekeeper):
-    """Scorekeeper Information with Appearances"""
+    """Scorekeeper Information with Appearances."""
 
-    appearances: Optional[ScorekeeperAppearances] = Field(
+    appearances: ScorekeeperAppearances | None = Field(
         default=None, title="List of Show Appearances"
     )
 
 
 class ScorekeepersDetails(BaseModel):
-    """List of Scorekeeper Details"""
+    """List of Scorekeeper Details."""
 
-    scorekeepers: List[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")
+    scorekeepers: list[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")
+    scorekeepers: list[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -1,146 +1,139 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Shows Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Shows Models."""
 
 from decimal import Decimal
-from typing import List, Optional, Union
+from typing import Annotated
+
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
 
 
 class Show(BaseModel):
-    """Show Information"""
+    """Show Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Show ID")
     date: str = Field(title="Show Date")
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Best Of Show")
+    show_url: str | None = Field(default=None, title="URL for Show Page on NPR.org")
 
 
 class Shows(BaseModel):
-    """List of Shows"""
+    """List of Shows."""
 
-    shows: List[Show] = Field(title="List of Shows")
+    shows: list[Show] = Field(title="List of Shows")
 
 
 class ShowLocation(BaseModel):
-    """Show Location Information"""
+    """Show Location Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Location ID")
-    slug: Optional[str] = Field(default=None, title="Location Slug String")
-    city: Optional[str] = Field(default=None, title="City")
-    state: Optional[str] = Field(default=None, title="State")
-    venue: Optional[str] = Field(default=None, title="Venue Name")
+    slug: str | None = Field(default=None, title="Location Slug String")
+    city: str | None = Field(default=None, title="City")
+    state: str | None = Field(default=None, title="State")
+    venue: str | None = Field(default=None, title="Venue Name")
 
 
 class ShowHost(BaseModel):
-    """Show Host Information"""
+    """Show Host Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Host ID")
     name: str = Field(title="Host Name")
-    slug: Optional[str] = Field(default=None, title="Host Slug String")
+    slug: str | None = Field(default=None, title="Host Slug String")
     guest: bool = Field(title="Guest Host")
 
 
 class ShowScorekeeper(BaseModel):
-    """Show Scorekeeper Information"""
+    """Show Scorekeeper Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Scorekeeper ID")
     name: str = Field(title="Scorekeeper Name")
-    slug: Optional[str] = Field(default=None, title="Scorekeeper Slug String")
+    slug: str | None = Field(default=None, title="Scorekeeper Slug String")
     guest: bool = Field(title="Guest Scorekeeper")
-    description: Optional[str] = Field(default=None, title="Scorekeeper Description")
+    description: str | None = Field(default=None, title="Scorekeeper Description")
 
 
 class ShowPanelist(BaseModel):
-    """Show Panelist Information"""
+    """Show Panelist Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
-    slug: Optional[str] = Field(default=None, title="Panelist Slug String")
-    lightning_round_start: Union[int, None] = Field(
+    slug: str | None = Field(default=None, title="Panelist Slug String")
+    lightning_round_start: int | None = Field(
         default=None, title="Lightning Fill-in-the-Blank Starting Score"
     )
-    lightning_round_start_decimal: Union[Decimal, None] = Field(
+    lightning_round_start_decimal: Decimal | None = Field(
         default=None, title="Lightning Fill-in-the-Blank Starting Decimal Score"
     )
-    lightning_round_correct: Union[int, None] = Field(
+    lightning_round_correct: int | None = Field(
         default=None, title="Lightning Fill-in-the-Blank Correct Answers"
     )
-    lightning_round_correct_decimal: Union[Decimal, None] = Field(
+    lightning_round_correct_decimal: Decimal | None = Field(
         default=None, title="Lightning Fill-in-the-Blank Correct Answers (Decimal)"
     )
-    score: Union[int, None] = Field(default=None, title="Panelist Score")
-    score_decimal: Optional[Decimal] = Field(
-        default=None, title="Panelist Decimal Score"
-    )
-    rank: Union[str, None] = Field(default=None, title="Panelist Rank")
+    score: int | None = Field(default=None, title="Panelist Score")
+    score_decimal: Decimal | None = Field(default=None, title="Panelist Decimal Score")
+    rank: str | None = Field(default=None, title="Panelist Rank")
 
 
 class ShowBluffPanelist(BaseModel):
-    """Show Bluff the Listener Panelist Information"""
+    """Show Bluff the Listener Panelist Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Panelist ID")
     name: str = Field(title="Panelist Name")
-    slug: Optional[str] = Field(default=None, title="Panelist Slug String")
+    slug: str | None = Field(default=None, title="Panelist Slug String")
 
 
 class ShowBluffDetails(BaseModel):
-    """Show Bluff the Listener Chosen and Correct Panelists"""
+    """Show Bluff the Listener Chosen and Correct Panelists."""
 
     segment: int = Field(title="Bluff Segment Number")
-    chosen_panelist: Optional[ShowBluffPanelist] = Field(
+    chosen_panelist: ShowBluffPanelist | None = Field(
         default=None, title="Chosen Panelist"
     )
-    correct_panelist: Optional[ShowBluffPanelist] = Field(
+    correct_panelist: ShowBluffPanelist | None = Field(
         default=None, title="Correct Panelist"
     )
 
 
 class ShowGuest(BaseModel):
-    """Show Guest Information"""
+    """Show Guest Information."""
 
     id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Guest ID")
     name: str = Field(title="Guest Name")
-    slug: Optional[str] = Field(default=None, title="Guest Slug String")
-    score: Union[int, None] = Field(default=None, title="Guest Score")
+    slug: str | None = Field(default=None, title="Guest Slug String")
+    score: int | None = Field(default=None, title="Guest Score")
     score_exception: bool = Field(default=False, title="Guest Scoring Exception")
 
 
 class ShowDetails(Show):
-    """Show Information, Host, Scorekeeper, Panelists, Guests and
-    Additional Details"""
+    """Show Information, Host, Scorekeeper, Panelists, Guests and Additional Details."""
 
-    location: Optional[ShowLocation] = Field(title="Show Location")
-    description: Optional[str] = Field(default=None, title="Show Description")
-    notes: Optional[str] = Field(
-        default=None, title="Show Notes (Plain Text or Markdown)"
-    )
-    host: Optional[ShowHost] = Field(default=None, title="Show Host")
-    scorekeeper: Optional[ShowScorekeeper] = Field(
-        default=None, title="Show Scorekeeper"
-    )
-    panelists: Optional[List[ShowPanelist]] = Field(
-        default=None, title="Show Panelists"
-    )
-    bluffs: Optional[List[ShowBluffDetails]] = Field(
+    location: ShowLocation | None = Field(default=None, title="Show Location")
+    description: str | None = Field(default=None, title="Show Description")
+    notes: str | None = Field(default=None, title="Show Notes (Plain Text or Markdown)")
+    host: ShowHost | None = Field(default=None, title="Show Host")
+    scorekeeper: ShowScorekeeper | None = Field(default=None, title="Show Scorekeeper")
+    panelists: list[ShowPanelist] | None = Field(default=None, title="Show Panelists")
+    bluffs: list[ShowBluffDetails] | None = Field(
         default=None, title="Bluff the Listener Information"
     )
-    guests: Optional[List[ShowGuest]] = Field(default=None, title="Show Guests")
+    guests: list[ShowGuest] | None = Field(default=None, title="Show Guests")
 
 
 class ShowsDetails(BaseModel):
-    """List of Show Details"""
+    """List of Show Details."""
 
-    shows: List[ShowDetails] = Field(
+    shows: list[ShowDetails] = Field(
         title="List of Show Information and Additional Details"
     )
 
 
 class ShowDates(BaseModel):
-    """List of Show Dates in ISO format (YYYY-MM-DD)"""
+    """List of Show Dates in ISO format (YYYY-MM-DD)."""
 
-    shows: List[str] = Field(title="List of Show Dates")
+    shows: list[str] = Field(title="List of Show Dates")
+    shows: list[str] = Field(title="List of Show Dates")

--- a/app/models/version.py
+++ b/app/models/version.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""App Version Models"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""App Version Models."""
 
 from pydantic import BaseModel, Field
 
 
 class Version(BaseModel):
-    """Wait Wait Stats API and Application Version Information"""
+    """Wait Wait Stats API and Application Version Information."""
 
     api: str = Field(title="Wait Wait Stats API Version")
     app: str = Field(title="Application Version")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""FastAPI application routers __init__.py for api.wwdt.me"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""FastAPI application routers __init__.py for api.wwdt.me."""

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -1,22 +1,22 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Not My Job Guests endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Not My Job Guests endpoints."""
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
+from typing import Annotated
+
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.guest import Guest
-from app.models.guests import (
-    Guest as ModelsGuest,
-    Guests as ModelsGuests,
-    GuestDetails as ModelsGuestDetails,
-    GuestsDetails as ModelsGuestsDetails,
-)
-from typing_extensions import Annotated
+
+from app.config import API_VERSION, load_config
+from app.models.guests import Guest as ModelsGuest
+from app.models.guests import GuestDetails as ModelsGuestDetails
+from app.models.guests import Guests as ModelsGuests
+from app.models.guests import GuestsDetails as ModelsGuestsDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/guests")
 _config = load_config()
@@ -32,10 +32,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_guests():
-    """Retrieve an array of Not My Job Guest objects, each containing:
-    Guest ID, name and slug string.
+    """Retrieve All Not My Job Guests.
 
-    Results are sorted by guest name."""
+    Returned data: Guest ID, name and slug string.
+
+    Guests are sorted by guest name.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guests = guest.retrieve_all()
@@ -46,13 +48,12 @@ async def get_guests():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guests from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "guests from the database",
-        )
+            detail="Database error occurred while retrieving guests from the database",
+        ) from None
 
 
 @router.get(
@@ -65,8 +66,10 @@ async def get_guests():
 async def get_guest_by_id(
     guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Not My Job Guest object, based on Guest ID,
-    containing: Guest ID, name and slug string."""
+    """Retrieve a Not My Job Guest by Guest ID.
+
+    Returned data: Guest ID, name and slug string.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guest_info = guest.retrieve_by_id(guest_id)
@@ -77,17 +80,18 @@ async def get_guest_by_id(
         else:
             return guest_info
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Guest ID {guest_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Guest ID {guest_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guest information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve guest information",
-        )
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
 
 
 @router.get(
@@ -100,8 +104,10 @@ async def get_guest_by_id(
 async def get_guest_by_slug(
     guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
 ):
-    """Retrieve a Not My Job Guest object, based on Guest slug string,
-    containing: Guest ID, name and slug string."""
+    """Retrieve a Not My Job Guest by Guest Slug String.
+
+    Returned data: Guest ID, name and slug string.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guest_info = guest.retrieve_by_slug(guest_slug.strip())
@@ -114,17 +120,16 @@ async def get_guest_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Guest slug string {guest_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guest information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve guest information",
-        )
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
 
 
 @router.get(
@@ -135,11 +140,12 @@ async def get_guest_by_slug(
 )
 @router.head("/details", include_in_schema=False)
 async def get_guests_details():
-    """Retrieve an array of Not My Job Guest objects, each containing:
-    Guest ID, name, slug string and their appearance details.
+    """Retrieve Details for All Not My Job Guests.
 
-    Results are sorted by guest name, with guest appearances sorted
-    by show date."""
+    Returned data: Guest ID, name, slug string, appearances and scores.
+
+    Guests are sorted by guest name. Appearances are sorted by date.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guests = guest.retrieve_all_details()
@@ -150,13 +156,12 @@ async def get_guests_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guests from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "guests from the database",
-        )
+            detail="Database error occurred while retrieving guests from the database",
+        ) from None
 
 
 @router.get(
@@ -169,10 +174,12 @@ async def get_guests_details():
 async def get_guest_details_by_id(
     guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Not My Job Guest object, based on Guest ID,
-    containing: Guest ID, name, slug string, and their appearance details.
+    """Retrieve Details for a Not My Job Guest by Guest ID.
 
-    Guest appearances are sorted by show date."""
+    Returned data: Guest ID, name, slug string, appearances and scores.
+
+    Appearances are sorted by date.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guest_details = guest.retrieve_details_by_id(guest_id)
@@ -183,17 +190,18 @@ async def get_guest_details_by_id(
         else:
             return guest_details
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Guest ID {guest_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Guest ID {guest_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guest information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve guest information",
-        )
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
 
 
 @router.get(
@@ -206,10 +214,12 @@ async def get_guest_details_by_id(
 async def get_guest_details_by_slug(
     guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
 ):
-    """Retrieve a Not My Job Guest object, based on Guest slug string,
-    containing: Guest ID, name, slug string, and their appearance details.
+    """Retrieve Details for a Not My Job Guest by Guest Slug String.
 
-    Guest appearances are sorted by show date."""
+    Returned data: Guest ID, name, slug string, appearances and scores.
+
+    Appearances are sorted by date.
+    """
     try:
         guest = Guest(database_connection=_database_connection)
         guest_details = guest.retrieve_details_by_slug(guest_slug.strip())
@@ -222,14 +232,13 @@ async def get_guest_details_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Guest slug string {guest_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve guest information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve guest information",
-        )
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -1,22 +1,22 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Hosts endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Hosts endpoints."""
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
+from typing import Annotated
+
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.host import Host
-from app.models.hosts import (
-    Host as ModelsHost,
-    Hosts as ModelsHosts,
-    HostDetails as ModelsHostDetails,
-    HostsDetails as ModelsHostsDetails,
-)
-from typing_extensions import Annotated
+
+from app.config import API_VERSION, load_config
+from app.models.hosts import Host as ModelsHost
+from app.models.hosts import HostDetails as ModelsHostDetails
+from app.models.hosts import Hosts as ModelsHosts
+from app.models.hosts import HostsDetails as ModelsHostsDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
 _config = load_config()
@@ -32,10 +32,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_hosts():
-    """Retrieve an array of Host objects, each containing: Host ID,
-    name, slug string, and gender.
+    """Retrieve All Hosts.
 
-    Results are sorted by host name."""
+    Returned data: Host ID, name, slug string and gender.
+
+    Hosts are sorted by host name.
+    """
     try:
         host = Host(database_connection=_database_connection)
         hosts = host.retrieve_all()
@@ -46,13 +48,12 @@ async def get_hosts():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve hosts from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "hosts from the database",
-        )
+            detail="Database error occurred while retrieving hosts from the database",
+        ) from None
 
 
 @router.get(
@@ -65,8 +66,10 @@ async def get_hosts():
 async def get_host_by_id(
     host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Host object, based on Host ID, containing: Host ID,
-    name, slug string, and gender."""
+    """Retrieve a Host by Host ID.
+
+    Returned data: Host ID, name, slug string and gender.
+    """
     try:
         host = Host(database_connection=_database_connection)
         host_info = host.retrieve_by_id(host_id)
@@ -75,17 +78,18 @@ async def get_host_by_id(
         else:
             return host_info
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Host ID {host_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Host ID {host_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve host information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve host information",
-        )
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
 
 
 @router.get(
@@ -98,8 +102,10 @@ async def get_host_by_id(
 async def get_host_by_slug(
     host_slug: Annotated[str, Path(title="The slug string of the host to get")]
 ):
-    """Retrieve a Host object, based on Host slug string, containing:
-    Host ID, name, slug string, and gender."""
+    """Retrieve a Host by Host Slug String.
+
+    Returned data: Host ID, name, slug string and gender.
+    """
     try:
         host = Host(database_connection=_database_connection)
         host_info = host.retrieve_by_slug(host_slug)
@@ -112,17 +118,16 @@ async def get_host_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Host slug string {host_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve host information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve host information",
-        )
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
 
 
 @router.get(
@@ -133,11 +138,12 @@ async def get_host_by_slug(
 )
 @router.head("/details", include_in_schema=False)
 async def get_hosts_details():
-    """Retrieve an array of Host objects, each containing: Host ID,
-    name, slug string, gender, and their appearance details.
+    """Retrieve Details for All Hosts.
 
-    Results are sorted by host name, with host appearances sorted by
-    show date."""
+    Returned data: Host ID, name, slug string, gender, and appearances.
+
+    Hosts are sorted by host name. Appearances are sorted by date.
+    """
     try:
         host = Host(database_connection=_database_connection)
         hosts = host.retrieve_all_details()
@@ -148,13 +154,12 @@ async def get_hosts_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve hosts from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "hosts from the database",
-        )
+            detail="Database error occurred while retrieving hosts from the database",
+        ) from None
 
 
 @router.get(
@@ -167,10 +172,12 @@ async def get_hosts_details():
 async def get_host_details_by_id(
     host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Host object, based on Host ID, containing: Host ID,
-    name, slug string, gender, and their appearance details.
+    """Retrieve Details for a Host by Host ID.
 
-    Host appearances are sorted by show date."""
+    Returned data: Host ID, name, slug string, gender, and appearances.
+
+    Appearances are sorted by date.
+    """
     try:
         host = Host(database_connection=_database_connection)
         host_details = host.retrieve_details_by_id(host_id)
@@ -179,17 +186,18 @@ async def get_host_details_by_id(
         else:
             return host_details
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Host ID {host_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Host ID {host_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve host information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve host information",
-        )
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
 
 
 @router.get(
@@ -202,10 +210,12 @@ async def get_host_details_by_id(
 async def get_host_details_by_slug(
     host_slug: Annotated[str, Path(title="The slug string of the guest to get")]
 ):
-    """Retrieve a Host object, based on Host slug string, containing:
-    Host ID, name, slug string, gender, and their appearance details.
+    """Retrieve Details for a Host by Host Slug String.
 
-    Host appearances are sorted by show date."""
+    Returned data: Host ID, name, slug string, gender, and appearances.
+
+    Appearances are sorted by date.
+    """
     try:
         host = Host(database_connection=_database_connection)
         host_details = host.retrieve_details_by_slug(host_slug)
@@ -218,14 +228,13 @@ async def get_host_details_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Host slug string {host_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve host information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve host information",
-        )
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -1,22 +1,22 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Locations endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Locations endpoints."""
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
+from typing import Annotated
+
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.location import Location
-from app.models.locations import (
-    Location as ModelsLocation,
-    Locations as ModelsLocations,
-    LocationDetails as ModelsLocationDetails,
-    LocationsDetails as ModelsLocationsDetails,
-)
-from typing_extensions import Annotated
+
+from app.config import API_VERSION, load_config
+from app.models.locations import Location as ModelsLocation
+from app.models.locations import LocationDetails as ModelsLocationDetails
+from app.models.locations import Locations as ModelsLocations
+from app.models.locations import LocationsDetails as ModelsLocationsDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/locations")
 _config = load_config()
@@ -32,10 +32,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_locations():
-    """Retrieve an array of Location objects, each containing:
-    Location ID, city, state, venue, and slug string.
+    """Retrieve All Show Locations.
 
-    Results are sorted by: city, state, venue name."""
+    Returned data: Location ID, city, state, venue and slug string.
+
+    Locations are sorted by: city, state, then venue name.
+    """
     try:
         location = Location(database_connection=_database_connection)
         locations = location.retrieve_all()
@@ -46,13 +48,12 @@ async def get_locations():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve locations from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "locations from the database",
-        )
+            detail="Database error occurred while retrieving locations from the database",
+        ) from None
 
 
 @router.get(
@@ -67,8 +68,10 @@ async def get_location_by_id(
         int, Path(title="The ID of the location to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Location object, based on Location ID, containing:
-    Location ID, city, state, venue, and slug string."""
+    """Retrieve a Show Location by Location ID.
+
+    Returned data: Location ID, city, state, venue and slug string.
+    """
     try:
         location = Location(database_connection=_database_connection)
         location_info = location.retrieve_by_id(location_id)
@@ -81,17 +84,16 @@ async def get_location_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Location ID {location_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve location information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve location information",
-        )
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
 
 
 @router.get(
@@ -104,8 +106,10 @@ async def get_location_by_id(
 async def get_location_by_slug(
     location_slug: Annotated[str, Path(title="The slug string of the location to get")]
 ):
-    """Retrieve a location object, based on Location slug string,
-    containing: Location ID, city, state, venue, and slug string."""
+    """Retrieve a Show Location by Location Slug String.
+
+    Returned data: Location ID, city, state, venue and slug string.
+    """
     try:
         location = Location(database_connection=_database_connection)
         location_info = location.retrieve_by_slug(location_slug.strip())
@@ -119,17 +123,16 @@ async def get_location_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Location slug string {location_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve location information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve location information",
-        )
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
 
 
 @router.get(
@@ -140,11 +143,14 @@ async def get_location_by_slug(
 )
 @router.head("/recordings", include_in_schema=False)
 async def get_locations_details():
-    """Retrieve an array of Location objects, each containing:
-    Location ID, city, state, venue, slug string, and an array of
+    """Retrieve Details for All Show Locations.
+
+    Returned data: Location ID, city, state, venue, slug string and
     recordings.
 
-    Results are sorted by: city, state, venue name."""
+    Locations are sorted by: city, state, then venue name. Recordings
+    are sorted by show date.
+    """
     try:
         location = Location(database_connection=_database_connection)
         locations = location.retrieve_all_details()
@@ -155,13 +161,12 @@ async def get_locations_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve locations from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "locations from the database",
-        )
+            detail="Database error occurred while retrieving locations from the database",
+        ) from None
 
 
 @router.get(
@@ -176,11 +181,13 @@ async def get_location_recordings_by_id(
         int, Path(title="The ID of the location to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Location object, based on Location ID, containing:
-    Location ID, city, state, venue, slug string, and an array of
+    """Retrieve Details for a Show Location by Location ID.
+
+    Returned data: Location ID, city, state, venue, slug string and
     recordings.
 
-    Recordings are sorted by show date."""
+    Recordings are sorted by show date.
+    """
     try:
         location = Location(database_connection=_database_connection)
         location_recordings = location.retrieve_details_by_id(location_id)
@@ -193,17 +200,17 @@ async def get_location_recordings_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Location ID {location_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve location information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to "
             "retrieve location information",
-        )
+        ) from None
 
 
 @router.get(
@@ -216,11 +223,13 @@ async def get_location_recordings_by_id(
 async def get_location_recordings_by_slug(
     location_slug: Annotated[str, Path(title="The slug string of the location to get")]
 ):
-    """Retrieve a Location object, based on Location slug string,
-    containing: Location ID, city, state, venue, slug string, and an
-    array of recordings.
+    """Retrieve Details for a Show Location by Location Slug String.
 
-    Recordings are sorted by show date."""
+    Returned data: Location ID, city, state, venue, slug string and
+    recordings.
+
+    Recordings are sorted by show date.
+    """
     try:
         location = Location(database_connection=_database_connection)
         location_details = location.retrieve_details_by_slug(location_slug.strip())
@@ -234,14 +243,14 @@ async def get_location_recordings_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Location slug string {location_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve location information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to "
             "retrieve location information",
-        )
+        ) from None

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -1,25 +1,29 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Panelists endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Panelists endpoints."""
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
+from typing import Annotated
+
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.panelist import Panelist, PanelistDecimalScores, PanelistScores
+
+from app.config import API_VERSION, load_config
+from app.models.panelists import Panelist as ModelsPanelist
+from app.models.panelists import PanelistDetails as ModelsPanelistDetails
+from app.models.panelists import Panelists as ModelsPanelists
 from app.models.panelists import (
-    Panelist as ModelsPanelist,
-    Panelists as ModelsPanelists,
-    PanelistDetails as ModelsPanelistDetails,
-    PanelistsDetails as ModelsPanelistsDetails,
-    PanelistScoresList as ModelsPanelistScoresList,
-    PanelistScoresOrderedPair as ModelsPanelistScoresOrderedPair,
     PanelistScoresGroupedOrderedPair as ModelsPanelistScoresGroupedOrderedPair,
 )
-from typing_extensions import Annotated
+from app.models.panelists import PanelistScoresList as ModelsPanelistScoresList
+from app.models.panelists import (
+    PanelistScoresOrderedPair as ModelsPanelistScoresOrderedPair,
+)
+from app.models.panelists import PanelistsDetails as ModelsPanelistsDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/panelists")
 _config = load_config()
@@ -35,10 +39,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_panelists():
-    """Retrieve an array of Panelist objects, each containing: Panelist
-    ID, name, slug string, and gender.
+    """Retrieve All Panelists.
 
-    Results are sorted by panelist name."""
+    Returned data: Panelist ID, name, slug string and gender.
+
+    Panelists are sorted by panelist name.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelists = panelist.retrieve_all()
@@ -49,13 +55,12 @@ async def get_panelists():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelists from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "panelists from the database",
-        )
+            detail="Database error occurred while retrieving panelists from the database",
+        ) from None
 
 
 @router.get(
@@ -70,8 +75,10 @@ async def get_panelist_by_id(
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Panelist object, based on Panelist ID, containing:
-    Panelist ID, name, slug string, and gender."""
+    """Retrieve a Panelist by Panelist ID.
+
+    Returned data: Panelist ID, name, slug string and gender.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_info = panelist.retrieve_by_id(panelist_id)
@@ -84,17 +91,16 @@ async def get_panelist_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist information",
-        )
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
 
 
 @router.get(
@@ -107,8 +113,10 @@ async def get_panelist_by_id(
 async def get_panelist_by_slug(
     panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
-    """Retrieve a Panelist object, based on Panelist slug string,
-    containing: Panelist ID, name, slug string, and gender."""
+    """Retrieve a Panelist by Panelist Slug String.
+
+    Returned data: Panelist ID, name, slug string and gender.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_info = panelist.retrieve_by_slug(panelist_slug.strip())
@@ -122,17 +130,16 @@ async def get_panelist_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist information",
-        )
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
 
 
 @router.get(
@@ -143,12 +150,14 @@ async def get_panelist_by_slug(
 )
 @router.head("/details", include_in_schema=False)
 async def get_panelists_details():
-    """Retrieve an array of Panelists objects, each containing:
-    Panelists ID, name, slug string, gender, and their statistics
-    and appearance details.
+    """Retrieve Details for All Panelists.
 
-    Results are sorted by panelist name, with panelist appearances
-    sorted by show date."""
+    Returned data: Panelists ID, name, slug string, gender, statistics
+    and appearances.
+
+    Panelists are sorted by panelist name. Appearances are sorted by
+    date.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelists = panelist.retrieve_all_details(
@@ -161,13 +170,12 @@ async def get_panelists_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelists from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "panelists from the database",
-        )
+            detail="Database error occurred while retrieving panelists from the database",
+        ) from None
 
 
 @router.get(
@@ -182,11 +190,13 @@ async def get_panelist_details_by_id(
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Panelist object, based on Panelist ID, containing:
-    Panelist ID, name, slug string, gender, and their statistics and
-    appearance details.
+    """Retrieve Details for a Panelist by Panelist ID.
 
-    Panelist appearances are sorted by show date."""
+    Returned data: Panelist ID, name, slug string, gender, statistics
+    and appearances.
+
+    Appearances are sorted by date.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_details = panelist.retrieve_details_by_id(
@@ -201,17 +211,16 @@ async def get_panelist_details_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist information",
-        )
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
 
 
 @router.get(
@@ -224,11 +233,13 @@ async def get_panelist_details_by_id(
 async def get_panelist_details_by_slug(
     panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
-    """Retrieve a Panelist object, based on Panelist slug string,
-    containing: Panelist ID, name, slug string, gender, and their
-    statistics and appearance details.
+    """Retrieve Details for a Panelist by Panelist Slug String.
 
-    Panelist appearances are sorted by show date."""
+    Returned data: Panelist ID, name, slug string, gender, statistics
+    and appearances.
+
+    Appearances are sorted by date.
+    """
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_details = panelist.retrieve_details_by_slug(
@@ -245,17 +256,16 @@ async def get_panelist_details_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist information",
-        )
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
 
 
 @router.get(
@@ -270,8 +280,10 @@ async def get_panelist_scores_by_id(
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve Panelist scores, based on Panelist ID, as a pair of
-    lists, one list of show dates and one list of corresponding scores."""
+    """Retrieve Panelist Scores by Panelist ID.
+
+    Returned data: One array with show dates and one array with scores.
+    """
     try:
         if _config["settings"]["use_decimal_scores"]:
             panelist_scores = PanelistDecimalScores(
@@ -293,17 +305,16 @@ async def get_panelist_scores_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
-        )
+            detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None
 
 
 @router.get(
@@ -316,9 +327,10 @@ async def get_panelist_scores_by_id(
 async def get_panelist_scores_by_slug(
     panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
-    """Retrieve Panelist scores, based on Panelist slug string, as a
-    pair of lists, one list of show dates and one list of corresponding
-    scores."""
+    """Retrieve Panelist Scores by Panelist Slug String.
+
+    Returned data: One array with show dates and one array with scores.
+    """
     try:
         if _config["settings"]["use_decimal_scores"]:
             panelist_scores = PanelistDecimalScores(
@@ -338,23 +350,21 @@ async def get_panelist_scores_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
-        )
+            detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None
 
 
 @router.get(
     "/scores/grouped-ordered-pair/id/{panelist_id}",
-    summary="Retrieve Panelist Scores as Ordered Pairs for Scores and Number "
-    "of Times It Has Been Earned by Panelist ID",
+    summary="Retrieve Panelist Scores as Ordered Pairs for Scores and Number of Times It Has Been Earned by Panelist ID",
     response_model=ModelsPanelistScoresGroupedOrderedPair,
     tags=["Panelists"],
 )
@@ -364,9 +374,10 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve Panelist scores, based on Panelist ID, as grouped
-    ordered pairs, each pair containing a score and the corresponding
-    number of times a panelist has earned that score.
+    """Retrieve Panelist Grouped Scores by Panelist ID.
+
+    Returned data: Array of two element arrays: one element with a score
+    and one element with corresponding score count.
     """
     try:
         if _config["settings"]["use_decimal_scores"]:
@@ -391,23 +402,21 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
-        )
+            detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None
 
 
 @router.get(
     "/scores/grouped-ordered-pair/slug/{panelist_slug}",
-    summary="Retrieve Panelist Scores as Ordered Pairs for Scores and Number "
-    "of Times It Has Been Earned by Panelist Slug String",
+    summary="Retrieve Panelist Scores as Ordered Pairs for Scores and Number of Times It Has Been Earned by Panelist Slug String",
     response_model=ModelsPanelistScoresGroupedOrderedPair,
     tags=["Panelists"],
 )
@@ -417,9 +426,10 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
 async def get_panelist_scores_grouped_ordered_pair_by_slug(
     panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
-    """Retrieve Panelist scores, based on Panelist slug string, as
-    grouped ordered pairs, each pair containing a score and the
-    corresponding number of times a panelist has earned that score.
+    """Retrieve Panelist Grouped Scores by Panelist Slug String.
+
+    Returned data: Array of two element arrays: one element with a score
+    and one element with corresponding score count.
     """
     try:
         if _config["settings"]["use_decimal_scores"]:
@@ -444,17 +454,16 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
-        )
+            detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None
 
 
 @router.get(
@@ -469,9 +478,10 @@ async def get_panelist_scores_ordered_pair_by_id(
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve Panelist scores, based on Panelist ID, as ordered
-    pairs, each pair containing the show date and the corresponding
-    score.
+    """Retrieve Panelist Scores as Ordered Pairs by Panelist ID.
+
+    Returned data: Array of two element arrays: one element with a show
+    date and one element with corresponding score.
     """
     try:
         if _config["settings"]["use_decimal_scores"]:
@@ -492,17 +502,17 @@ async def get_panelist_scores_ordered_pair_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to "
             "retrieve panelist scores",
-        )
+        ) from None
 
 
 @router.get(
@@ -515,9 +525,10 @@ async def get_panelist_scores_ordered_pair_by_id(
 async def get_panelist_scores_ordered_pair_by_slug(
     panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
 ):
-    """Retrieve Panelist scores, based on Panelist slug string, as
-    ordered pairs, each pair containing the show date and the
-    corresponding score.
+    """Retrieve Panelist Scores as Ordered Pairs by Panelist Slug String.
+
+    Returned data: Array of two element arrays: one element with a show
+    date and one element with corresponding score.
     """
     try:
         if _config["settings"]["use_decimal_scores"]:
@@ -542,14 +553,13 @@ async def get_panelist_scores_ordered_pair_by_slug(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve panelist scores"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
-        )
+            detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -1,22 +1,22 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Scorekeeper endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Scorekeeper endpoints."""
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
+from typing import Annotated
+
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.scorekeeper import Scorekeeper
-from app.models.scorekeepers import (
-    Scorekeeper as ModelsScorekeeper,
-    Scorekeepers as ModelsScorekeepers,
-    ScorekeeperDetails as ModelsScorekeeperDetails,
-    ScorekeepersDetails as ModelsScorekeepersDetails,
-)
-from typing_extensions import Annotated
+
+from app.config import API_VERSION, load_config
+from app.models.scorekeepers import Scorekeeper as ModelsScorekeeper
+from app.models.scorekeepers import ScorekeeperDetails as ModelsScorekeeperDetails
+from app.models.scorekeepers import Scorekeepers as ModelsScorekeepers
+from app.models.scorekeepers import ScorekeepersDetails as ModelsScorekeepersDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/scorekeepers")
 _config = load_config()
@@ -32,10 +32,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_scorekeepers():
-    """Retrieve an array of Scorekeepers objects, each containing:
-    Scorekeepers ID, name, slug string, and gender.
+    """Retrieve All Scorekeepers.
 
-    Results are stored by scorekeeper name."""
+    Returned data: Scorekeeper ID, name, slug string and gender.
+
+    Scorekeepers are sorted by scorekeeper name.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeepers = scorekeeper.retrieve_all()
@@ -46,13 +48,12 @@ async def get_scorekeepers():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeepers from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "scorekeepers from the database",
-        )
+            detail="Database error occurred while retrieving scorekeepers from the database",
+        ) from None
 
 
 @router.get(
@@ -67,8 +68,10 @@ async def get_scorekeeper_by_id(
         int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Scorekeeper object, based on Scorekeeper ID,
-    containing: Scorekeeper ID, name, slug string, and gender."""
+    """Retrieve a Scorekeeper by Scorekeeper ID.
+
+    Returned data: Scorekeeper ID, name, slug string and gender.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_info = scorekeeper.retrieve_by_id(scorekeeper_id)
@@ -81,17 +84,16 @@ async def get_scorekeeper_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeeper information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve scorekeeper information",
-        )
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
 
 
 @router.get(
@@ -106,8 +108,10 @@ async def get_scorekeeper_by_slug(
         str, Path(title="The slug string of the scorekeeper to get")
     ]
 ):
-    """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
-    containing: Scorekeeper ID, name, slug string, and gender."""
+    """Retrieve a Scorekeeper by Scorekeeper Slug String.
+
+    Returned data: Scorekeeper ID, name, slug string and gender.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_info = scorekeeper.retrieve_by_slug(scorekeeper_slug.strip())
@@ -122,17 +126,16 @@ async def get_scorekeeper_by_slug(
         raise HTTPException(
             status_code=404,
             detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeeper information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve scorekeeper information",
-        )
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
 
 
 @router.get(
@@ -143,12 +146,14 @@ async def get_scorekeeper_by_slug(
 )
 @router.head("/details", include_in_schema=False)
 async def get_scorekeepers_details():
-    """Retrieve an array of Scorekeepers objects, each containing:
-    Scorekeepers ID, name, slug string, gender, and their appearance
-    details.
+    """Retrieve Details for All Scorekeepers.
 
-    Results are sorted by scorekeeper name, with scorekeeper appearances
-    sorted by show date."""
+    Returned data: Scorekeepers ID, name, slug string, gender and
+    appearances.
+
+    Scorekeepers are sorted by scorekeeper name. Appearances are sorted
+    by show date.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeepers = scorekeeper.retrieve_all_details()
@@ -159,13 +164,12 @@ async def get_scorekeepers_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeepers from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "scorekeepers from the database",
-        )
+            detail="Database error occurred while retrieving scorekeepers from the database",
+        ) from None
 
 
 @router.get(
@@ -180,11 +184,13 @@ async def get_scorekeeper_details_by_id(
         int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
     ]
 ):
-    """Retrieve a Scorekeeper object, based on Scorekeeper ID,
-    containing: Scorekeeper ID, name, slug string, gender, and their
-    appearance details.
+    """Retrieve Details for a Scorekeeper by Scorekeeper ID.
 
-    Scorekeeper appearances are sorted by show date."""
+    Returned data: Scorekeeper ID, name, slug string, gender and
+    appearances.
+
+    Appearances are sorted by show date.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_details = scorekeeper.retrieve_details_by_id(scorekeeper_id)
@@ -197,17 +203,16 @@ async def get_scorekeeper_details_by_id(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeeper information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve scorekeeper information",
-        )
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
 
 
 @router.get(
@@ -222,11 +227,13 @@ async def get_scorekeeper_details_by_slug(
         str, Path(title="The slug string of the scorekeeper to get")
     ]
 ):
-    """Retrieve a Scorekeeper object, based on Scorekeeper slug string,
-    containing: Scorekeeper ID, name, slug string, gender, and their
-    appearance details.
+    """Retrieve Details for a Scorekeeper by Scorekeeper ID.
 
-    Scorekeeper appearances are sorted by show date."""
+    Returned data: Scorekeeper ID, name, slug string, gender and
+    appearances.
+
+    Appearances are sorted by show date.
+    """
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_details = scorekeeper.retrieve_details_by_slug(
@@ -243,14 +250,13 @@ async def get_scorekeeper_details_by_slug(
         raise HTTPException(
             status_code=404,
             detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve scorekeeper information"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve scorekeeper information",
-        )
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -1,25 +1,24 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Scorekeeper endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Scorekeeper endpoints."""
 
 from datetime import date
+from typing import Annotated
 
-from app.config import API_VERSION, load_config
-from fastapi import APIRouter, HTTPException, Path
 import mysql.connector
+from fastapi import APIRouter, HTTPException, Path
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.show import Show
-from app.models.shows import (
-    Show as ModelsShow,
-    ShowDates as ModelsShowDates,
-    Shows as ModelsShows,
-    ShowDetails as ModelsShowDetails,
-    ShowsDetails as ModelsShowsDetails,
-)
-from typing_extensions import Annotated
+
+from app.config import API_VERSION, load_config
+from app.models.shows import Show as ModelsShow
+from app.models.shows import ShowDates as ModelsShowDates
+from app.models.shows import ShowDetails as ModelsShowDetails
+from app.models.shows import Shows as ModelsShows
+from app.models.shows import ShowsDetails as ModelsShowsDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/shows")
 _config = load_config()
@@ -35,10 +34,12 @@ _database_connection = mysql.connector.connect(**_database_config)
 )
 @router.head("", include_in_schema=False)
 async def get_shows():
-    """Retrieve an array of Show objects, each containing: Show ID,
-    date and basic information.
+    """Retrieve All Shows.
 
-    Results are sorted by show date."""
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_all()
@@ -49,13 +50,13 @@ async def get_shows():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve shows from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while retrieving "
             "shows from the database",
-        )
+        ) from None
 
 
 @router.get(
@@ -68,8 +69,10 @@ async def get_shows():
 async def get_show_by_id(
     show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Show object, based on Show ID, containing: Show ID,
-    date and basic information."""
+    """Retrieve a Show by Show ID.
+
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_id(show_id)
@@ -78,18 +81,19 @@ async def get_show_by_id(
         else:
             return show_info
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Show ID {show_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Show ID {show_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -102,8 +106,10 @@ async def get_show_by_id(
 async def get_show_by_date_string(
     show_date: Annotated[date, Path(title="ISO date for the show to get")]
 ):
-    """Retrieve a Show object, based on show date in ISO format
-    (YYYY-MM-DD), containing: Show ID, date and basic information."""
+    """Retrieve a Show by Show Date in YYYY-MM-DD format.
+
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_date_string(show_date.isoformat())
@@ -114,18 +120,19 @@ async def get_show_by_date_string(
         else:
             return show_info
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Show date {show_date} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Show date {show_date} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -138,10 +145,12 @@ async def get_show_by_date_string(
 async def get_shows_by_year(
     year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
 ):
-    """Retrieve an array of Show objects, based on year, containing:
-    Show ID, date and basic information.
+    """Retrieve All Shows by Year.
 
-    Results are sorted by show date."""
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_year(year)
@@ -152,18 +161,19 @@ async def get_shows_by_year(
         else:
             return {"shows": shows}
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Shows for {year:04d} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Shows for {year:04d} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -177,10 +187,12 @@ async def get_shows_by_year_month(
     year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
     month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
 ):
-    """Retrieve an array of Show objects, based on year and month,
-    containing: Show ID, date and basic information.
+    """Retrieve All Shows by Year and Month.
 
-    Results are sorted by show date."""
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_year_month(year, month)
@@ -193,18 +205,17 @@ async def get_shows_by_year_month(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Shows for {year:04d}-{month:02d} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -218,8 +229,12 @@ async def get_show_by_month_day(
     month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
     day: Annotated[int, Path(title="The day to get shows for", ge=1, le=31)],
 ):
-    """Retrieve a Show object, based on month and day, containing: Show
-    ID, date and basic information."""
+    """Retrieve All Shows by Month and Day.
+
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_month_day(month, day)
@@ -234,18 +249,17 @@ async def get_show_by_month_day(
         raise HTTPException(
             status_code=404,
             detail=f"Shows for month {month:02d} and {day:02d} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -260,8 +274,10 @@ async def get_show_by_date(
     month: Annotated[int, Path(title="The month to get a show for", ge=1, le=12)],
     day: Annotated[int, Path(title="The day to get a show for", ge=1, le=31)],
 ):
-    """Retrieve a Show object, based on year, month and day, containing:
-    Show ID, date and basic information."""
+    """Retrieve a Show by Year, Month and Day.
+
+    Returned data: Show ID, date, Best Of flag and Repeat flag
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_date(year, month, day)
@@ -276,18 +292,17 @@ async def get_show_by_date(
         raise HTTPException(
             status_code=404,
             detail=f"Shows for {year:04d}-{month:02d}-{day:02d} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -298,9 +313,10 @@ async def get_show_by_date(
 )
 @router.head("/dates", include_in_schema=False)
 async def get_all_show_dates():
-    """Retrieve an array of all show dates in ISO format (YYYY-MM-DD).
+    """Retrieve All Show Dates.
 
-    Results are sorted by show date."""
+    Returned data: Show dates in YYYY-MM-DD format
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_all_dates()
@@ -311,13 +327,12 @@ async def get_all_show_dates():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve shows from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "shows from the database",
-        )
+            detail="Database error occurred while retrieving shows from the database",
+        ) from None
 
 
 @router.get(
@@ -328,10 +343,14 @@ async def get_all_show_dates():
 )
 @router.head("/details", include_in_schema=False)
 async def get_shows_details():
-    """Retrieve an array of Show objects, each containing: Show ID,
-    date, Host, Scorekeeper, Panelists, Guests and other information.
+    """Retrieve Details For All Shows.
 
-    Results are sorted by show date."""
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_all_details(
@@ -344,13 +363,12 @@ async def get_shows_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve shows from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "shows from the database",
-        )
+            detail="Database error occurred while retrieving shows from the database",
+        ) from None
 
 
 @router.get(
@@ -363,9 +381,12 @@ async def get_shows_details():
 async def get_show_details_by_date_string(
     show_date: Annotated[date, Path(title="ISO date for the show to get")]
 ):
-    """Retrieve an array of Show objects, based on show date in ISO
-    format (YYYY-MM-DD), containing: Show ID, date, Host, Scorekeeper,
-    Panelists, Guests and other information."""
+    """Retrieve Details for a Show by Show Date in YYYY-MM-DD format.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_details = show.retrieve_details_by_date_string(
@@ -379,18 +400,19 @@ async def get_show_details_by_date_string(
         else:
             return show_details
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Show date {show_date} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Show date {show_date} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -403,11 +425,14 @@ async def get_show_details_by_date_string(
 async def get_shows_details_by_year(
     year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
 ):
-    """Retrieve an array of Show objects, based on year, containing:
-    Show ID, date, Host, Scorekeeper, Panelists, Guests and other
-    information.
+    """Retrieve Details for Shows by Year.
 
-    Results are sorted by show date."""
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_details_by_year(
@@ -420,18 +445,19 @@ async def get_shows_details_by_year(
         else:
             return {"shows": shows}
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Shows for {year:04d} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Shows for {year:04d} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -445,11 +471,14 @@ async def get_shows_details_by_year_month(
     year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
     month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
 ):
-    """Retrieve an array of Show objects, based on year and month,
-    containing: Show ID, date, Host, Scorekeeper, Panelists, Guests and
-    other information.
+    """Retrieve Details for Shows by Year and Month.
 
-    Results are sorted by show date."""
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_details_by_year_month(
@@ -466,18 +495,17 @@ async def get_shows_details_by_year_month(
     except ValueError:
         raise HTTPException(
             status_code=404, detail=f"Shows for {year:04d}-{month:02d} not found"
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -491,8 +519,14 @@ async def get_show_details_by_month_day(
     month: Annotated[int, Path(title="The month to get shows for", ge=1, le=12)],
     day: Annotated[int, Path(title="The day to get shows for", ge=1, le=31)],
 ):
-    """Retrieve a Show object, based on month and day, containing: Show
-    ID, date, Host, Scorekeeper, Panelists, Guests and other information."""
+    """Retrieve Details for Shows by Month and Day.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_details_by_month_day(
@@ -509,18 +543,17 @@ async def get_show_details_by_month_day(
         raise HTTPException(
             status_code=404,
             detail=f"Shows for month {month:02d} and day {day:02d} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -535,9 +568,12 @@ async def get_show_details_by_date(
     month: Annotated[int, Path(title="The month to get a show for", ge=1, le=12)],
     day: Annotated[int, Path(title="The day to get a show for", ge=1, le=31)],
 ):
-    """Retrieve a Show object, based on year, month and day, containing:
-    Show ID, date, Host, Scorekeeper, Panelists, Guests and other
-    information."""
+    """Retrieve Details for a Shows by Year, Month and Day.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_details = show.retrieve_details_by_date(
@@ -557,18 +593,17 @@ async def get_show_details_by_date(
         raise HTTPException(
             status_code=404,
             detail=f"Shows for {year:04d}-{month:02d}-{day:02d} not found",
-        )
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -581,8 +616,12 @@ async def get_show_details_by_date(
 async def get_show_details_by_id(
     show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
 ):
-    """Retrieve a Show object, based on Show ID, containing: Show ID,
-    date, Host, Scorekeeper, Panelists, Guests and other information."""
+    """Retrieve Details for a Shows by Show ID.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+    """
     try:
         show = Show(database_connection=_database_connection)
         show_details = show.retrieve_details_by_id(
@@ -593,18 +632,19 @@ async def get_show_details_by_id(
         else:
             return show_details
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Show ID {show_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Show ID {show_id} not found"
+        ) from None
     except ProgrammingError:
         raise HTTPException(
             status_code=500,
             detail="Unable to retrieve show information from the database",
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "show information from the database",
-        )
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
 
 
 @router.get(
@@ -615,11 +655,14 @@ async def get_show_details_by_id(
 )
 @router.head("/details/recent", include_in_schema=False)
 async def get_shows_recent_details():
-    """Retrieve an array of Show objects for recent shows, each
-    containing: Show ID, date, Host, Scorekeeper, Panelists, Guests
-    and other information.
+    """Retrieve Details for Recent Shows.
 
-    Results are sorted by show date."""
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    location, description, notes, host, scorekeeper, panelists, Bluff
+    information and Not My Job guests
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_recent_details(
@@ -632,13 +675,12 @@ async def get_shows_recent_details():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve shows from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "shows from the database",
-        )
+            detail="Database error occurred while retrieving shows from the database",
+        ) from None
 
 
 @router.get(
@@ -649,10 +691,12 @@ async def get_shows_recent_details():
 )
 @router.head("/recent", include_in_schema=False)
 async def get_shows_recent():
-    """Retrieve an array of Show objects for recent shows, each
-    containing: Show ID, date and basic information.
+    """Retrieve Recent Shows.
 
-    Results are sorted by show date."""
+    Return data: Show ID, date, Best Of flag and Repeat flag
+
+    Shows are sorted by date.
+    """
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_recent()
@@ -663,10 +707,9 @@ async def get_shows_recent():
     except ProgrammingError:
         raise HTTPException(
             status_code=500, detail="Unable to retrieve shows from the database"
-        )
+        ) from None
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "shows from the database",
-        )
+            detail="Database error occurred while retrieving shows from the database",
+        ) from None

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -1,13 +1,14 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""API routes for Application Version endpoints"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""API routes for Application Version endpoints."""
 
-from app.config import API_VERSION, APP_VERSION
 from fastapi import APIRouter
 from wwdtm import VERSION as WWDTM_VERSION
+
+from app.config import API_VERSION, APP_VERSION
 from app.models.version import Version
 
 router = APIRouter(prefix=f"/v{API_VERSION}/version")
@@ -21,8 +22,7 @@ router = APIRouter(prefix=f"/v{API_VERSION}/version")
 )
 @router.head("", include_in_schema=False)
 async def get_version():
-    """Retrieve Wait Wait Stats API version, application version, and
-    wwdtm library version"""
+    """Retrieves API, Application and Wait Wait Stats Library Versions."""
     return {
         "api": API_VERSION,
         "app": APP_VERSION,

--- a/config.json.dist
+++ b/config.json.dist
@@ -20,6 +20,7 @@
         "contact_email": "",
         "contact_name": "",
         "contact_url": "",
+        "patreon_url": "",
         "use_decimal_scores": false
     }
 }

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""pytest conftest.py File"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""pytest conftest.py File."""

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Gunicorn Configuration File"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Gunicorn Configuration File."""
 
 # Make a copy of this file and name it `gunicorn.conf.py` in order
 # for it to be picked up by Gunicorn upon startup. Update any of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
-required-version = "23.11.0"
+required-version = "23.12.1"
 target-version = ["py310", "py311", "py312"]
+line-length = 88
 
 [tool.pytest.ini_options]
 minversion = "7.4"
@@ -10,5 +11,85 @@ filterwarnings = [
 norecursedirs = [
     ".git",
     "venv",
-    "static",
+    "dist",
+    ".eggs",
+    "wwdtm.egg-info",
 ]
+
+[tool.ruff]
+target-version = "py310"
+select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D",   # pydocstyle
+    "E",   # Error
+    "F",   # pyflakes
+    "I",   # isort
+    "ISC", # flake8-implicit-str-concat
+    "N",   # pep8-naming
+    "PGH", # pygrep-hooks
+    "PTH", # flake8-use-pathlib
+    "Q",   # flake8-quotes
+    "S",   # bandit
+    "SIM", # flake8-simplify
+    "TRY", # tryceratops
+    "UP",  # pyupgrade
+    "W",   # Warning
+    "YTT", # flake8-2020
+]
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+line-length = 88 # Must agree with Black
+
+[tool.ruff.flake8-bugbear]
+extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "S101",   # use of "assert"
+    "S102",   # use of "exec"
+    "S106",   # possible hardcoded password.
+    "PGH001", # use of "eval"
+]
+
+[tool.ruff.pep8-naming]
+staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,15 @@
-flake8==6.1.0
-pycodestyle==2.11.0
-pytest==7.4.3
-black==23.11.0
+ruff==0.1.13
+black==23.12.1
+pytest==7.4.4
 
-pydantic==2.5.2
-fastapi==0.104.1
-uvicorn[standard]==0.24.0.post1
+pydantic==2.5.3
+fastapi==0.109.0
+uvicorn[standard]==0.26.0
 gunicorn==21.2.0
-httpx==0.25.2
+httpx==0.26.0
 aiofiles==23.2.1
 jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.6.1
+wwdtm==2.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ uvicorn[standard]==0.24.0.post1
 gunicorn==21.2.0
 httpx==0.25.2
 aiofiles==23.2.1
-jinja2==3.1.2
+jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.24.0.post1
 gunicorn==21.2.0
 httpx==0.25.2
 aiofiles==23.2.1
-jinja2==3.1.2
+jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pydantic==2.5.2
-fastapi==0.104.1
-uvicorn[standard]==0.24.0.post1
+pydantic==2.5.3
+fastapi==0.109.0
+uvicorn[standard]==0.26.0
 gunicorn==21.2.0
-httpx==0.25.2
+httpx==0.26.0
 aiofiles==23.2.1
 jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.6.1
+wwdtm==2.8.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,11 @@
             <a class="links" href="https://stats.wwdt.me/">Stats Page →</a>
             {% endif %}
         </div>
+        {% if patreon_url %}
+        <div class="page-link">
+            <a class="links" href="{{ patreon_url }}">Support the Wait Wait Stats project at Patreon →</a>
+        </div>
+        {% endif %}
     </main>
 </body>
 </html>

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/guests routes
-"""
-from fastapi.testclient import TestClient
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/guests routes."""
 
-from app.main import app
+import pytest
+from fastapi.testclient import TestClient
+
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_guests():
-    """Test /v2.0/guests route"""
-
+    """Test /v2.0/guests route."""
     response = client.get(f"/v{API_VERSION}/guests")
     guests = response.json()
 
@@ -29,8 +28,7 @@ def test_guests():
 
 @pytest.mark.parametrize("guest_id", [54])
 def test_guests_id(guest_id: int):
-    """Test /v2.0/guests/id/{guest_id} route"""
-
+    """Test /v2.0/guests/id/{guest_id} route."""
     response = client.get(f"/v{API_VERSION}/guests/id/{guest_id}")
     guest = response.json()
 
@@ -43,8 +41,7 @@ def test_guests_id(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_guests_slug(guest_slug: str):
-    """Test /v2.0/guests/slug/{guest_slug} route"""
-
+    """Test /v2.0/guests/slug/{guest_slug} route."""
     response = client.get(f"/v{API_VERSION}/guests/slug/{guest_slug}")
     guest = response.json()
 
@@ -56,8 +53,7 @@ def test_guests_slug(guest_slug: str):
 
 
 def test_guests_details():
-    """Test /v2.0/guests/details route"""
-
+    """Test /v2.0/guests/details route."""
     response = client.get(f"/v{API_VERSION}/guests/details")
     guests = response.json()
 
@@ -71,8 +67,7 @@ def test_guests_details():
 
 @pytest.mark.parametrize("guest_id", [54])
 def test_guests_details_id(guest_id: int):
-    """Test /v2.0/guests/details/id/{guest_id} route"""
-
+    """Test /v2.0/guests/details/id/{guest_id} route."""
     response = client.get(f"/v{API_VERSION}/guests/details/id/{guest_id}")
     guest = response.json()
 
@@ -86,8 +81,7 @@ def test_guests_details_id(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_guests_details_slug(guest_slug: str):
-    """Test /v2.0/guests/details/slug/{guest_slug} route"""
-
+    """Test /v2.0/guests/details/slug/{guest_slug} route."""
     response = client.get(f"/v{API_VERSION}/guests/details/slug/{guest_slug}")
     guest = response.json()
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/hosts routes
-"""
-from fastapi.testclient import TestClient
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/hosts routes."""
 
-from app.main import app
+import pytest
+from fastapi.testclient import TestClient
+
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_hosts():
-    """Test /v2.0/hosts route"""
-
+    """Test /v2.0/hosts route."""
     response = client.get(f"/v{API_VERSION}/hosts")
     hosts = response.json()
 
@@ -29,8 +28,7 @@ def test_hosts():
 
 @pytest.mark.parametrize("host_id", [2])
 def test_hosts_id(host_id: int):
-    """Test /v2.0/hosts/id/{host_id} route"""
-
+    """Test /v2.0/hosts/id/{host_id} route."""
     response = client.get(f"/v{API_VERSION}/hosts/id/{host_id}")
     host = response.json()
 
@@ -43,8 +41,7 @@ def test_hosts_id(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_hosts_slug(host_slug: str):
-    """Test /v2.0/hosts/slug/{host_slug} route"""
-
+    """Test /v2.0/hosts/slug/{host_slug} route."""
     response = client.get(f"/v{API_VERSION}/hosts/slug/{host_slug}")
     host = response.json()
 
@@ -56,8 +53,7 @@ def test_hosts_slug(host_slug: str):
 
 
 def test_hosts_details():
-    """Test /v2.0/hosts/details route"""
-
+    """Test /v2.0/hosts/details route."""
     response = client.get(f"/v{API_VERSION}/hosts/details")
     hosts = response.json()
 
@@ -71,8 +67,7 @@ def test_hosts_details():
 
 @pytest.mark.parametrize("host_id", [2])
 def test_hosts_details_id(host_id: int):
-    """Test /v2.0/hosts/details/id/{host_id} route"""
-
+    """Test /v2.0/hosts/details/id/{host_id} route."""
     response = client.get(f"/v{API_VERSION}/hosts/details/id/{host_id}")
     host = response.json()
 
@@ -86,8 +81,7 @@ def test_hosts_details_id(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_hosts_details_slug(host_slug: str):
-    """Test /v2.0/hosts/details/slug/{host_slug} route"""
-
+    """Test /v2.0/hosts/details/slug/{host_slug} route."""
     response = client.get(f"/v{API_VERSION}/hosts/details/slug/{host_slug}")
     host = response.json()
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/locations routes
-"""
-from fastapi.testclient import TestClient
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/locations routes."""
 
-from app.main import app
+import pytest
+from fastapi.testclient import TestClient
+
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_locations():
-    """Test /v2.0/locations route"""
-
+    """Test /v2.0/locations route."""
     response = client.get(f"/v{API_VERSION}/locations")
     locations = response.json()
 
@@ -30,8 +29,7 @@ def test_locations():
 
 @pytest.mark.parametrize("location_id", [32])
 def test_locations_id(location_id: int):
-    """Test /v2.0/locations/id/{location_id} route"""
-
+    """Test /v2.0/locations/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/id/{location_id}")
     location = response.json()
 
@@ -46,8 +44,7 @@ def test_locations_id(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
 def test_locations_slug(location_slug: str):
-    """Test /v2.0/locations/slug/{location_slug} route"""
-
+    """Test /v2.0/locations/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/slug/{location_slug}")
     location = response.json()
 
@@ -61,8 +58,7 @@ def test_locations_slug(location_slug: str):
 
 
 def test_locations_recordings():
-    """Test /v2.0/locations/recordings route"""
-
+    """Test /v2.0/locations/recordings route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings")
     locations = response.json()
 
@@ -78,8 +74,7 @@ def test_locations_recordings():
 
 @pytest.mark.parametrize("location_id", [32])
 def test_locations_recordings_id(location_id: int):
-    """Test /v2.0/locations/recordings/id/{location_id} route"""
-
+    """Test /v2.0/locations/recordings/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/id/{location_id}")
     location = response.json()
 
@@ -95,8 +90,7 @@ def test_locations_recordings_id(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
 def test_locations_recordings_slug(location_slug: str):
-    """Test /v2.0/locations/recordings/slug/{location_slug} route"""
-
+    """Test /v2.0/locations/recordings/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/slug/{location_slug}")
     location = response.json()
 

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/panelists routes
-"""
-from fastapi.testclient import TestClient
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/panelists routes."""
 
-from app.main import app
+import pytest
+from fastapi.testclient import TestClient
+
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_panelists():
-    """Test /v2.0/panelists route"""
-
+    """Test /v2.0/panelists route."""
     response = client.get(f"/v{API_VERSION}/panelists")
     panelists = response.json()
 
@@ -29,8 +28,7 @@ def test_panelists():
 
 @pytest.mark.parametrize("panelist_id", [30])
 def test_panelists_id(panelist_id: int):
-    """Test /v2.0/panelists/id/{panelist_id} route"""
-
+    """Test /v2.0/panelists/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/id/{panelist_id}")
     panelist = response.json()
 
@@ -43,8 +41,7 @@ def test_panelists_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelists_slug(panelist_slug: str):
-    """Test /v2.0/panelists/slug/{panelist_slug} route"""
-
+    """Test /v2.0/panelists/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/slug/{panelist_slug}")
     panelist = response.json()
 
@@ -56,8 +53,7 @@ def test_panelists_slug(panelist_slug: str):
 
 
 def test_panelists_details():
-    """Test /v2.0/panelists/details route"""
-
+    """Test /v2.0/panelists/details route."""
     response = client.get(f"/v{API_VERSION}/panelists/details")
     panelists = response.json()
 
@@ -71,8 +67,7 @@ def test_panelists_details():
 
 @pytest.mark.parametrize("panelist_id", [30])
 def test_panelists_details_id(panelist_id: int):
-    """Test /v2.0/panelists/details/id/{panelist_id} route"""
-
+    """Test /v2.0/panelists/details/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/details/id/{panelist_id}")
     panelist = response.json()
 
@@ -86,8 +81,7 @@ def test_panelists_details_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelists_details_slug(panelist_slug: str):
-    """Test /v2.0/panelists/details/slug/{panelist_slug} route"""
-
+    """Test /v2.0/panelists/details/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/details/slug/{panelist_slug}")
     panelist = response.json()
 
@@ -101,8 +95,7 @@ def test_panelists_details_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [30])
 def test_panelists_scores_id(panelist_id: int):
-    """Test /v2.0/panelists/scores/id/{panelist_id} route"""
-
+    """Test /v2.0/panelists/scores/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/scores/id/{panelist_id}")
     scores = response.json()
 
@@ -112,8 +105,7 @@ def test_panelists_scores_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelists_scores_slug(panelist_slug: str):
-    """Test /v2.0/panelists/scores/slug/{panelist_slug} route"""
-
+    """Test /v2.0/panelists/scores/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/scores/slug/{panelist_slug}")
     scores = response.json()
 
@@ -123,8 +115,7 @@ def test_panelists_scores_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [30])
 def test_panelists_scores_ordered_pair_id(panelist_id: int):
-    """Test /v2.0/panelists/scores/ordered-pair/id/{panelist_id} route"""
-
+    """Test /v2.0/panelists/scores/ordered-pair/id/{panelist_id} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/ordered-pair/id/{panelist_id}"
     )
@@ -136,8 +127,7 @@ def test_panelists_scores_ordered_pair_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelists_scores_ordered_pair_slug(panelist_slug: str):
-    """Test /v2.0/panelists/scores/ordered-pair/slug/{panelist_slug} route"""
-
+    """Test /v2.0/panelists/scores/ordered-pair/slug/{panelist_slug} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/ordered-pair/slug/{panelist_slug}"
     )
@@ -149,8 +139,7 @@ def test_panelists_scores_ordered_pair_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [30])
 def test_panelists_scores_grouped_ordered_pair_id(panelist_id: int):
-    """Test /v2.0/panelists/scores/grouped-ordered-pair/id/{panelist_id} route"""
-
+    """Test /v2.0/panelists/scores/grouped-ordered-pair/id/{panelist_id} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/id/{panelist_id}"
     )
@@ -162,8 +151,7 @@ def test_panelists_scores_grouped_ordered_pair_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelists_scores_grouped_ordered_pair_slug(panelist_slug: str):
-    """Test /v2.0/panelists/scores/grouped-ordered-pair/slug/{panelist_slug} route"""
-
+    """Test /v2.0/panelists/scores/grouped-ordered-pair/slug/{panelist_slug} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/slug/{panelist_slug}"
     )

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/scorekeepers routes
-"""
-from fastapi.testclient import TestClient
-import pytest
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/scorekeepers routes."""
 
-from app.main import app
+import pytest
+from fastapi.testclient import TestClient
+
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_scorekeepers():
-    """Test /v2.0/scorekeepers route"""
-
+    """Test /v2.0/scorekeepers route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers")
     scorekeepers = response.json()
 
@@ -29,8 +28,7 @@ def test_scorekeepers():
 
 @pytest.mark.parametrize("scorekeeper_id", [11])
 def test_scorekeepers_id(scorekeeper_id: int):
-    """Test /v2.0/scorekeepers/id/{scorekeeper_id} route"""
-
+    """Test /v2.0/scorekeepers/id/{scorekeeper_id} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/id/{scorekeeper_id}")
     scorekeeper = response.json()
 
@@ -43,8 +41,7 @@ def test_scorekeepers_id(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["bill-kurtis"])
 def test_scorekeepers_slug(scorekeeper_slug: str):
-    """Test /v2.0/scorekeepers/slug/{scorekeeper_slug} route"""
-
+    """Test /v2.0/scorekeepers/slug/{scorekeeper_slug} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/slug/{scorekeeper_slug}")
     scorekeeper = response.json()
 
@@ -56,8 +53,7 @@ def test_scorekeepers_slug(scorekeeper_slug: str):
 
 
 def test_scorekeepers_details():
-    """Test /v2.0/scorekeepers/details route"""
-
+    """Test /v2.0/scorekeepers/details route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/details")
     scorekeepers = response.json()
 
@@ -71,8 +67,7 @@ def test_scorekeepers_details():
 
 @pytest.mark.parametrize("scorekeeper_id", [11])
 def test_scorekeepers_details_id(scorekeeper_id: int):
-    """Test /v2.0/scorekeepers/details/id/{scorekeeper_id} route"""
-
+    """Test /v2.0/scorekeepers/details/id/{scorekeeper_id} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/details/id/{scorekeeper_id}")
     scorekeeper = response.json()
 
@@ -86,8 +81,7 @@ def test_scorekeepers_details_id(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["bill-kurtis"])
 def test_scorekeepers_details_slug(scorekeeper_slug: str):
-    """Test /v2.0/scorekeepers/details/slug/{scorekeeper_slug} route"""
-
+    """Test /v2.0/scorekeepers/details/slug/{scorekeeper_slug} route."""
     response = client.get(
         f"/v{API_VERSION}/scorekeepers/details/slug/{scorekeeper_slug}"
     )

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,23 +1,22 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/shows routes
-"""
-from fastapi.testclient import TestClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/shows routes."""
+
 import pytest
+from fastapi.testclient import TestClient
 from requests.models import Response
 
-from app.main import app
 from app.config import API_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_shows():
-    """Test /v2.0/shows route"""
-
+    """Test /v2.0/shows route."""
     response = client.get(f"/v{API_VERSION}/shows")
     shows = response.json()
 
@@ -27,12 +26,12 @@ def test_shows():
     assert "date" in shows["shows"][0]
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("show_id", [1083])
 def test_shows_id(show_id: int):
-    """Test /v2.0/shows/id/{show_id} route"""
-
+    """Test /v2.0/shows/id/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/id/{show_id}")
     show = response.json()
 
@@ -42,12 +41,12 @@ def test_shows_id(show_id: int):
     assert "date" in show
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
 
 
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
 def test_shows_date_iso_show_date(show_date: str):
-    """Test /v2.0/shows/date/iso/{show_id} route"""
-
+    """Test /v2.0/shows/date/iso/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/iso/{show_date}")
     show = response.json()
 
@@ -57,12 +56,12 @@ def test_shows_date_iso_show_date(show_date: str):
     assert show["date"] == show_date
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
 
 
 @pytest.mark.parametrize("year", [2006])
 def test_shows_date_year(year: int):
-    """Test /v2.0/shows/date/{year} route"""
-
+    """Test /v2.0/shows/date/{year} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}")
     shows = response.json()
     formatted_year = f"{year:04}"
@@ -74,12 +73,12 @@ def test_shows_date_year(year: int):
     assert shows["shows"][0]["date"].startswith(formatted_year)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("year, month", [(2006, 6)])
 def test_shows_date_year_month(year: int, month: int):
-    """Test /v2.0/shows/date/{year}/{month} route"""
-
+    """Test /v2.0/shows/date/{year}/{month} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}")
     shows = response.json()
     formatted_year_month = f"{year:04}-{month:02}"
@@ -91,12 +90,12 @@ def test_shows_date_year_month(year: int, month: int):
     assert shows["shows"][0]["date"].startswith(formatted_year_month)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("month, day", [(10, 27)])
 def test_shows_date_month_day(month: int, day: int):
-    """Test /v2.0/shows/date/month-day/{month}/{day} route"""
-
+    """Test /v2.0/shows/date/month-day/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/month-day/{month}/{day}")
     shows = response.json()
     formatted_month_day = f"{month:02}-{day:02}"
@@ -108,12 +107,12 @@ def test_shows_date_month_day(month: int, day: int):
     assert shows["shows"][0]["date"].find(formatted_month_day)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
 def test_shows_date_year_month_day(year: int, month: int, day: int):
-    """Test /v2.0/shows/date/{year}/{month}/{day} route"""
-
+    """Test /v2.0/shows/date/{year}/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}/{day}")
     show = response.json()
     formatted_date = f"{year:04}-{month:02}-{day:02}"
@@ -124,11 +123,11 @@ def test_shows_date_year_month_day(year: int, month: int, day: int):
     assert show["date"] == formatted_date
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
 
 
 def test_show_dates():
-    """Test /v2.0/shows/dates route"""
-
+    """Test /v2.0/shows/dates route."""
     response = client.get(f"/v{API_VERSION}/shows/dates")
     dates = response.json()
 
@@ -138,8 +137,7 @@ def test_show_dates():
 
 
 def test_shows_details():
-    """Test /v2.0/shows/details route"""
-
+    """Test /v2.0/shows/details route."""
     response = client.get(f"/v{API_VERSION}/shows/details")
     shows = response.json()
 
@@ -149,6 +147,7 @@ def test_shows_details():
     assert "date" in shows["shows"][0]
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -159,8 +158,7 @@ def test_shows_details():
 
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
 def test_shows_details_date_iso_show_date(show_date: str):
-    """Test /v2.0/shows/details/date/iso/{show_id} route"""
-
+    """Test /v2.0/shows/details/date/iso/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/iso/{show_date}")
     show = response.json()
 
@@ -170,6 +168,7 @@ def test_shows_details_date_iso_show_date(show_date: str):
     assert show["date"] == show_date
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -180,8 +179,7 @@ def test_shows_details_date_iso_show_date(show_date: str):
 
 @pytest.mark.parametrize("year", [2006])
 def test_shows_details_date_year(year: int):
-    """Test /v2.0/shows/details/date/{year} route"""
-
+    """Test /v2.0/shows/details/date/{year} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}")
     shows = response.json()
     formatted_year = f"{year:04}"
@@ -193,6 +191,7 @@ def test_shows_details_date_year(year: int):
     assert shows["shows"][0]["date"].startswith(formatted_year)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -203,8 +202,7 @@ def test_shows_details_date_year(year: int):
 
 @pytest.mark.parametrize("year, month", [(2006, 6)])
 def test_shows_details_date_year_month(year: int, month: int):
-    """Test /v2.0/shows/details/date/{year}/{month} route"""
-
+    """Test /v2.0/shows/details/date/{year}/{month} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}")
     shows = response.json()
     formatted_year_month = f"{year:04}-{month:02}"
@@ -216,6 +214,7 @@ def test_shows_details_date_year_month(year: int, month: int):
     assert shows["shows"][0]["date"].startswith(formatted_year_month)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -226,8 +225,7 @@ def test_shows_details_date_year_month(year: int, month: int):
 
 @pytest.mark.parametrize("month, day", [(10, 27)])
 def test_shows_details_date_month_day(month: int, day: int):
-    """Test /v2.0/shows/details/date/month-day/{month}/{day} route"""
-
+    """Test /v2.0/shows/details/date/month-day/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/month-day/{month}/{day}")
     shows = response.json()
     formatted_month_day = f"{month:02}-{day:02}"
@@ -239,6 +237,7 @@ def test_shows_details_date_month_day(month: int, day: int):
     assert shows["shows"][0]["date"].find(formatted_month_day)
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -249,8 +248,7 @@ def test_shows_details_date_month_day(month: int, day: int):
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
 def test_shows_details_date_year_month_day(year: int, month: int, day: int):
-    """Test /v2.0/shows/details/date/{year}/{month}/{day} route"""
-
+    """Test /v2.0/shows/details/date/{year}/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}/{day}")
     show = response.json()
     formatted_date = f"{year:04}-{month:02}-{day:02}"
@@ -261,6 +259,7 @@ def test_shows_details_date_year_month_day(year: int, month: int, day: int):
     assert show["date"] == formatted_date
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -271,8 +270,7 @@ def test_shows_details_date_year_month_day(year: int, month: int, day: int):
 
 @pytest.mark.parametrize("show_id", [1083])
 def test_shows_details_id(show_id: int):
-    """Test /v2.0/shows/details/id/{show_id} route"""
-
+    """Test /v2.0/shows/details/id/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/id/{show_id}")
     show = response.json()
 
@@ -282,6 +280,7 @@ def test_shows_details_id(show_id: int):
     assert "date" in show
     assert "best_of" in show
     assert "repeat_show" in show
+    assert "show_url" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -291,8 +290,7 @@ def test_shows_details_id(show_id: int):
 
 
 def test_shows_details_recent():
-    """Test /v2.0/shows/details/recent route"""
-
+    """Test /v2.0/shows/details/recent route."""
     response = client.get(f"/v{API_VERSION}/shows/details/recent")
     shows = response.json()
 
@@ -302,6 +300,7 @@ def test_shows_details_recent():
     assert "date" in shows["shows"][0]
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -311,8 +310,7 @@ def test_shows_details_recent():
 
 
 def test_shows_recent():
-    """Test /v2.0/shows/recent route"""
-
+    """Test /v2.0/shows/recent route."""
     response = client.get(f"/v{API_VERSION}/shows/recent")
     shows = response.json()
 
@@ -322,3 +320,4 @@ def test_shows_recent():
     assert "date" in shows["shows"][0]
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing /v2.0/version route
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing /v2.0/version route."""
+
 from fastapi.testclient import TestClient
 from wwdtm import VERSION as WWDTM_VERSION
 
-from app.main import app
 from app.config import API_VERSION, APP_VERSION
+from app.main import app
 
 client = TestClient(app)
 
 
 def test_version():
-    """Test /version route"""
-
+    """Test /version route."""
     response = client.get(f"/v{API_VERSION}/version")
     version = response.json()
 


### PR DESCRIPTION
## Application Changes

- Starting with application version 2.8.0 of the Stats API, the minimum required version of the Wait Wait Stats Database is 4.5
- Add support for returning show URL value from the Wait Wait Stats Database as `show_url` in returned show objects
- Code cleanup and updating docstrings

## Component Changes

- Upgrade wwdtm from 2.6.1 to 2.8.0
- Upgrade pydantic from 2.5.2 to 2.5.3
- Upgrade fastapi from 0.104.1 to 0.109.0
- Upgrade uvicorn from 0.24.0.post1 to 0.26.0
- Upgrade httpx from 0.25.2 to 0.26.0

## Development Changes

- Switch to Ruff for code linting and formatting (with the help of Black)
- Upgrade black from 23.11.0 to 23.12.1
- Upgrade pytest from 7.4.3 from 7.4.4