### PR TITLE
Add support for GitHub Sponsor link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changes
 
+## 2.8.2
+
+### Application Changes
+
+- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key
+
 ## 2.8.1
 
 ### Application Changes
 
 - Update Show route docstrings to include mention of NPR.org show URL in the returned data
+- Add support for Patreon link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.patreon_url` config key
 
 ## 2.8.0
 

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.8.1"
+APP_VERSION = "2.8.2"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -55,11 +55,17 @@ async def default_page(request: Request):
         settings = config["settings"]
         stats_url: str | None = settings.get("stats_url", None)
         patreon_url: str | None = settings.get("patreon_url", None)
+        github_sponsor_url: str | None = settings.get("github_sponsor_url", None)
     else:
         stats_url = None
     return templates.TemplateResponse(
         "index.html",
-        {"request": request, "stats_url": stats_url, "patreon_url": patreon_url},
+        {
+            "request": request,
+            "stats_url": stats_url,
+            "patreon_url": patreon_url,
+            "github_sponsor_url": github_sponsor_url,
+        },
     )
 
 

--- a/config.json.dist
+++ b/config.json.dist
@@ -21,6 +21,7 @@
         "contact_name": "",
         "contact_url": "",
         "patreon_url": "",
+        "github_sponsor_url": "",
         "use_decimal_scores": false
     }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,11 @@
             <a class="links" href="https://stats.wwdt.me/">Stats Page →</a>
             {% endif %}
         </div>
+        {% if github_sponsor_url %}
+        <div class="page-link">
+            <a class="links" href="{{ github_sponsor_url }}">Sponsor the Wait Wait Stats project at GitHub →</a>
+        </div>
+        {% endif %}
         {% if patreon_url %}
         <div class="page-link">
             <a class="links" href="{{ patreon_url }}">Support the Wait Wait Stats project at Patreon →</a>


### PR DESCRIPTION
## Application Changes

- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key