### PR TITLE
Fix sorting of panelists by decimal scores for show details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.8.4
 
-## Component Changes
+### Component Changes
 
 - Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.8.4
+
+## Component Changes
+
+- Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly
+
 ## 2.8.3
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.8.3"
+APP_VERSION = "2.8.4"
 
 
 def load_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.8.0
+wwdtm==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.8.0
+wwdtm==2.8.1


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly