### PR TITLE
Bump gunicorn, ruff and pytest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2.8.6
+
+### Component Changes
+
+- Upgrade gunicorn from 21.2.0 to 22.0.0
+
+### Development Changes
+
+- Upgrade ruff from 0.1.13 to 0.3.6
+- Upgrade pytest from 7.4.4 to 8.1.1
+
 ## 2.8.5
 
 ### Development Changes

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.8.5"
+APP_VERSION = "2.8.6"
 
 
 def load_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,40 @@ norecursedirs = [
 
 [tool.ruff]
 target-version = "py310"
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+line-length = 88 # Must agree with Black
+
+[tool.ruff.lint]
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -38,44 +72,13 @@ select = [
     "YTT", # flake8-2020
 ]
 
-exclude = [
-    "migrations",
-    "__pycache__",
-    "manage.py",
-    "settings.py",
-    "env",
-    ".env",
-    "venv",
-    ".venv",
-]
-
-ignore = [
-    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "D200",
-    "D401",
-    "E402",
-    "E501",
-    "F401",
-    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
-    "S608",
-]
-line-length = 88 # Must agree with Black
-
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -90,5 +93,5 @@ convention = "pep257"
     "S106",   # possible hardcoded password.
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
-ruff==0.1.13
+ruff==0.3.6
 black==24.3.0
-pytest==7.4.4
+pytest==8.1.1
 
 pydantic==2.5.3
 fastapi==0.109.1
 uvicorn[standard]==0.26.0
-gunicorn==21.2.0
+gunicorn==22.0.0
 httpx==0.26.0
 aiofiles==23.2.1
 jinja2==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==2.5.3
 fastapi==0.109.1
 uvicorn[standard]==0.26.0
-gunicorn==21.2.0
+gunicorn==22.0.0
 httpx==0.26.0
 aiofiles==23.2.1
 jinja2==3.1.3


### PR DESCRIPTION
## Component Changes

- Upgrade gunicorn from 21.2.0 to 22.0.0

## Development Changes

- Upgrade ruff from 0.1.13 to 0.3.6
- Upgrade pytest from 7.4.4 to 8.1.1