### PR TITLE
Add support for location latitude/longitude and host/panelist/scorekeeper preferred pronouns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.9.0
+
+### Application Changes
+
+- Starting with application version 2.9.0 of the Stats API, the minimum required version of the Wait Wait Stats Database is 4.6
+- Add `latitude` and `longitude` to any location object returned. If a value for either are present in the Stats Database, a string representation of a decimal would be returned. If not, `null` would be returned.
+- Add `pronouns` to any host, panelist and scorekeeper object returned. If a corresponding value is present in the State Database, a string would be returned. If not, `null` would be returned.
+
+### Component Changes
+
+- Upgrade wwdtm from 2.8.1 to 2.9.0
+- Upgrade fastapi from 0.109.1 to 0.110.2
+- Upgrade pydantic from 2.5.3 to 2.7.0
+
 ## 2.8.6
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changes
 
-## 2.9.0
+## 2.9.1
+
+### Application Changes
+
+- Create `LocationCoordinates` and `ShowLocationCoordinates` models to contain location latitude and longitude values for locations and shows respectively
+
+### Component Changes
+
+- Upgrade wwdtm from 2.9.0 to 2.9.1
+
+## 2.9.0 (Unreleased)
 
 ### Application Changes
 

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.8.6"
+APP_VERSION = "2.9.0"
 
 
 def load_config(

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -17,6 +17,7 @@ class Host(BaseModel):
     name: str = Field(title="Host Name")
     slug: str | None = Field(default=None, title="Host Slug String")
     gender: str | None = Field(default=None, title="Host Gender")
+    pronouns: str | None = Field(default=None, title="Host Pronouns")
 
 
 class Hosts(BaseModel):

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -11,6 +11,13 @@ from typing import Annotated
 from pydantic import BaseModel, Field
 
 
+class LocationCoordinates(BaseModel):
+    """Coordinates for a Location."""
+
+    latitude: Decimal | None = Field(default=None, title="Venue Latitude")
+    longitude: Decimal | None = Field(default=None, title="Venue Longitude")
+
+
 class Location(BaseModel):
     """Location Information."""
 
@@ -18,8 +25,9 @@ class Location(BaseModel):
     city: str | None = Field(default=None, title="City")
     state: str | None = Field(default=None, title="State")
     venue: str | None = Field(default=None, title="Venue Name")
-    latitude: Decimal | None = Field(default=None, title="Venue Latitude")
-    longitude: Decimal | None = Field(default=None, title="Venue Longitude")
+    coordinates: LocationCoordinates | None = Field(
+        default=None, title="Location Coordinates"
+    )
     slug: str | None = Field(default=None, title="Location Slug String")
 
 

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Locations Models."""
 
+from decimal import Decimal
 from typing import Annotated
 
 from pydantic import BaseModel, Field
@@ -17,6 +18,8 @@ class Location(BaseModel):
     city: str | None = Field(default=None, title="City")
     state: str | None = Field(default=None, title="State")
     venue: str | None = Field(default=None, title="Venue Name")
+    latitude: Decimal | None = Field(default=None, title="Venue Latitude")
+    longitude: Decimal | None = Field(default=None, title="Venue Longitude")
     slug: str | None = Field(default=None, title="Location Slug String")
 
 

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -18,6 +18,7 @@ class Panelist(BaseModel):
     name: str = Field(title="Panelist Name")
     slug: str | None = Field(default=None, title="Panelist Slug String")
     gender: str | None = Field(default=None, title="Panelist Gender")
+    pronouns: str | None = Field(default=None, title="Panelist Pronouns")
 
 
 class Panelists(BaseModel):
@@ -106,9 +107,7 @@ class MilestonesFirst(BaseModel):
 class MilestonesMostRecent(BaseModel):
     """Panelist Most Recent Appearance Milestone."""
 
-    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(
-        title="Most Recent Show ID"
-    )
+    show_id: Annotated[int, Field(ge=0, lt=2**31)] = Field(title="Most Recent Show ID")
     show_date: str = Field(title="Most Recent Show Date")
 
 

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -17,6 +17,7 @@ class Scorekeeper(BaseModel):
     name: str = Field(title="Scorekeeper Name")
     slug: str | None = Field(default=None, title="Scorekeeper Slug String")
     gender: str | None = Field(default=None, title="Scorekeeper Gender")
+    pronouns: str | None = Field(default=None, title="Scorekeeper Pronouns")
 
 
 class Scorekeepers(BaseModel):

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -27,6 +27,13 @@ class Shows(BaseModel):
     shows: list[Show] = Field(title="List of Shows")
 
 
+class ShowLocationCoordinates(BaseModel):
+    """Coordinates for a Show Location."""
+
+    latitude: Decimal | None = Field(default=None, title="Venue Latitude")
+    longitude: Decimal | None = Field(default=None, title="Venue Longitude")
+
+
 class ShowLocation(BaseModel):
     """Show Location Information."""
 
@@ -35,6 +42,9 @@ class ShowLocation(BaseModel):
     city: str | None = Field(default=None, title="City")
     state: str | None = Field(default=None, title="State")
     venue: str | None = Field(default=None, title="Venue Name")
+    coordinates: ShowLocationCoordinates | None = Field(
+        default=None, title="Location Coordinates"
+    )
 
 
 class ShowHost(BaseModel):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.9.0
+wwdtm==2.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@ ruff==0.3.6
 black==24.3.0
 pytest==8.1.1
 
-pydantic==2.5.3
-fastapi==0.109.1
+pydantic==2.7.0
+fastapi==0.110.2
 uvicorn[standard]==0.26.0
 gunicorn==22.0.0
 httpx==0.26.0
@@ -12,4 +12,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.8.1
+wwdtm==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.8.1
+wwdtm==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.3
 email-validator==2.1.0.post1
 requests==2.31.0
 
-wwdtm==2.9.0
+wwdtm==2.9.1

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -23,6 +23,7 @@ def test_hosts():
     assert "hosts" in hosts
     assert "id" in hosts["hosts"][0]
     assert "name" in hosts["hosts"][0]
+    assert "pronouns" in hosts["hosts"][0]
     assert "slug" in hosts["hosts"][0]
 
 
@@ -36,6 +37,7 @@ def test_hosts_id(host_id: int):
     assert "id" in host
     assert host["id"] == host_id
     assert "name" in host
+    assert "pronouns" in host
     assert "slug" in host
 
 
@@ -48,6 +50,7 @@ def test_hosts_slug(host_slug: str):
     assert response.status_code == 200
     assert "id" in host
     assert "name" in host
+    assert "pronouns" in host
     assert "slug" in host
     assert host["slug"] == host_slug
 
@@ -61,6 +64,7 @@ def test_hosts_details():
     assert "hosts" in hosts
     assert "id" in hosts["hosts"][0]
     assert "name" in hosts["hosts"][0]
+    assert "pronouns" in hosts["hosts"][0]
     assert "slug" in hosts["hosts"][0]
     assert "appearances" in hosts["hosts"][0]
 
@@ -75,6 +79,7 @@ def test_hosts_details_id(host_id: int):
     assert "id" in host
     assert host["id"] == host_id
     assert "name" in host
+    assert "pronouns" in host
     assert "slug" in host
     assert "appearances" in host
 
@@ -88,6 +93,7 @@ def test_hosts_details_slug(host_slug: str):
     assert response.status_code == 200
     assert "id" in host
     assert "name" in host
+    assert "pronouns" in host
     assert "slug" in host
     assert host["slug"] == host_slug
     assert "appearances" in host

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -25,8 +25,10 @@ def test_locations():
     assert "venue" in locations["locations"][0]
     assert "city" in locations["locations"][0]
     assert "state" in locations["locations"][0]
-    assert "latitude" in locations["locations"][0]
-    assert "longitude" in locations["locations"][0]
+    assert "coordinates" in locations["locations"][0]
+    if locations["locations"][0]["coordinates"]:
+        assert "latitude" in locations["locations"][0]["coordinates"]
+        assert "longitude" in locations["locations"][0]["coordinates"]
 
 
 @pytest.mark.parametrize("location_id", [32])
@@ -42,8 +44,10 @@ def test_locations_id(location_id: int):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
-    assert "latitude" in location
-    assert "longitude" in location
+    assert "coordinates" in location
+    if location["coordinates"]:
+        assert "latitude" in location["coordinates"]
+        assert "longitude" in location["coordinates"]
 
 
 @pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
@@ -59,8 +63,9 @@ def test_locations_slug(location_slug: str):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
-    assert "latitude" in location
-    assert "longitude" in location
+    if location["coordinates"]:
+        assert "latitude" in location["coordinates"]
+        assert "longitude" in location["coordinates"]
 
 
 def test_locations_recordings():
@@ -75,8 +80,10 @@ def test_locations_recordings():
     assert "venue" in locations["locations"][0]
     assert "city" in locations["locations"][0]
     assert "state" in locations["locations"][0]
-    assert "latitude" in locations["locations"][0]
-    assert "longitude" in locations["locations"][0]
+    assert "coordinates" in locations["locations"][0]
+    if locations["locations"][0]["coordinates"]:
+        assert "latitude" in locations["locations"][0]["coordinates"]
+        assert "longitude" in locations["locations"][0]["coordinates"]
     assert "recordings" in locations["locations"][0]
 
 
@@ -93,8 +100,9 @@ def test_locations_recordings_id(location_id: int):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
-    assert "latitude" in location
-    assert "longitude" in location
+    if location["coordinates"]:
+        assert "latitude" in location["coordinates"]
+        assert "longitude" in location["coordinates"]
     assert "recordings" in location
 
 
@@ -111,6 +119,7 @@ def test_locations_recordings_slug(location_slug: str):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
-    assert "latitude" in location
-    assert "longitude" in location
+    if location["coordinates"]:
+        assert "latitude" in location["coordinates"]
+        assert "longitude" in location["coordinates"]
     assert "recordings" in location

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -25,6 +25,8 @@ def test_locations():
     assert "venue" in locations["locations"][0]
     assert "city" in locations["locations"][0]
     assert "state" in locations["locations"][0]
+    assert "latitude" in locations["locations"][0]
+    assert "longitude" in locations["locations"][0]
 
 
 @pytest.mark.parametrize("location_id", [32])
@@ -40,6 +42,8 @@ def test_locations_id(location_id: int):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
+    assert "latitude" in location
+    assert "longitude" in location
 
 
 @pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
@@ -55,6 +59,8 @@ def test_locations_slug(location_slug: str):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
+    assert "latitude" in location
+    assert "longitude" in location
 
 
 def test_locations_recordings():
@@ -69,6 +75,8 @@ def test_locations_recordings():
     assert "venue" in locations["locations"][0]
     assert "city" in locations["locations"][0]
     assert "state" in locations["locations"][0]
+    assert "latitude" in locations["locations"][0]
+    assert "longitude" in locations["locations"][0]
     assert "recordings" in locations["locations"][0]
 
 
@@ -85,6 +93,8 @@ def test_locations_recordings_id(location_id: int):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
+    assert "latitude" in location
+    assert "longitude" in location
     assert "recordings" in location
 
 
@@ -101,4 +111,6 @@ def test_locations_recordings_slug(location_slug: str):
     assert "venue" in location
     assert "city" in location
     assert "state" in location
+    assert "latitude" in location
+    assert "longitude" in location
     assert "recordings" in location

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -23,6 +23,7 @@ def test_panelists():
     assert "panelists" in panelists
     assert "id" in panelists["panelists"][0]
     assert "name" in panelists["panelists"][0]
+    assert "pronouns" in panelists["panelists"][0]
     assert "slug" in panelists["panelists"][0]
 
 
@@ -36,6 +37,7 @@ def test_panelists_id(panelist_id: int):
     assert "id" in panelist
     assert panelist["id"] == panelist_id
     assert "name" in panelist
+    assert "pronouns" in panelist
     assert "slug" in panelist
 
 
@@ -48,6 +50,7 @@ def test_panelists_slug(panelist_slug: str):
     assert response.status_code == 200
     assert "id" in panelist
     assert "name" in panelist
+    assert "pronouns" in panelist
     assert "slug" in panelist
     assert panelist["slug"] == panelist_slug
 
@@ -61,6 +64,7 @@ def test_panelists_details():
     assert "panelists" in panelists
     assert "id" in panelists["panelists"][0]
     assert "name" in panelists["panelists"][0]
+    assert "pronouns" in panelists["panelists"][0]
     assert "slug" in panelists["panelists"][0]
     assert "appearances" in panelists["panelists"][0]
 
@@ -75,6 +79,7 @@ def test_panelists_details_id(panelist_id: int):
     assert "id" in panelist
     assert panelist["id"] == panelist_id
     assert "name" in panelist
+    assert "pronouns" in panelist
     assert "slug" in panelist
     assert "appearances" in panelist
 
@@ -88,6 +93,7 @@ def test_panelists_details_slug(panelist_slug: str):
     assert response.status_code == 200
     assert "id" in panelist
     assert "name" in panelist
+    assert "pronouns" in panelist
     assert "slug" in panelist
     assert panelist["slug"] == panelist_slug
     assert "appearances" in panelist

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -23,6 +23,7 @@ def test_scorekeepers():
     assert "scorekeepers" in scorekeepers
     assert "id" in scorekeepers["scorekeepers"][0]
     assert "name" in scorekeepers["scorekeepers"][0]
+    assert "pronouns" in scorekeepers["scorekeepers"][0]
     assert "slug" in scorekeepers["scorekeepers"][0]
 
 
@@ -36,6 +37,7 @@ def test_scorekeepers_id(scorekeeper_id: int):
     assert "id" in scorekeeper
     assert scorekeeper["id"] == scorekeeper_id
     assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
     assert "slug" in scorekeeper
 
 
@@ -48,6 +50,7 @@ def test_scorekeepers_slug(scorekeeper_slug: str):
     assert response.status_code == 200
     assert "id" in scorekeeper
     assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
     assert "slug" in scorekeeper
     assert scorekeeper["slug"] == scorekeeper_slug
 
@@ -61,6 +64,7 @@ def test_scorekeepers_details():
     assert "scorekeepers" in scorekeepers
     assert "id" in scorekeepers["scorekeepers"][0]
     assert "name" in scorekeepers["scorekeepers"][0]
+    assert "pronouns" in scorekeepers["scorekeepers"][0]
     assert "slug" in scorekeepers["scorekeepers"][0]
     assert "appearances" in scorekeepers["scorekeepers"][0]
 
@@ -75,6 +79,7 @@ def test_scorekeepers_details_id(scorekeeper_id: int):
     assert "id" in scorekeeper
     assert scorekeeper["id"] == scorekeeper_id
     assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
     assert "slug" in scorekeeper
     assert "appearances" in scorekeeper
 
@@ -90,6 +95,7 @@ def test_scorekeepers_details_slug(scorekeeper_slug: str):
     assert response.status_code == 200
     assert "id" in scorekeeper
     assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
     assert "slug" in scorekeeper
     assert scorekeeper["slug"] == scorekeeper_slug
     assert "appearances" in scorekeeper


### PR DESCRIPTION
## Application Changes

- Starting with application version 2.9.0 of the Stats API, the minimum required version of the Wait Wait Stats Database is 4.6
- Add `latitude` and `longitude` to any location object returned, encapsulated within `coordinates`. If a value for either are present in the Stats Database, a string representation of a decimal would be returned. If not, `null` would be returned.
- Add `pronouns` to any host, panelist and scorekeeper object returned. If a corresponding value is present in the State Database, a string would be returned. If not, `null` would be returned.

## Component Changes

- Upgrade wwdtm from 2.8.1 to 2.9.1
- Upgrade fastapi from 0.109.1 to 0.110.2
- Upgrade pydantic from 2.5.3 to 2.7.0