### PR TITLE
Bump Jinja2 to 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2.9.1.post1
+
+**Note:** The `APP_VERSION` was not correctly incremented with version 2.9.1 and has been corrected with this release.
+
+### Component Changes
+
+- Upgrade Jinja2 from 3.1.3 to 3.1.4
+
 ## 2.9.1
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.9.0"
+APP_VERSION = "2.9.0.post1"
 
 
 def load_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ uvicorn[standard]==0.26.0
 gunicorn==22.0.0
 httpx==0.26.0
 aiofiles==23.2.1
-jinja2==3.1.3
+jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.26.0
 gunicorn==22.0.0
 httpx==0.26.0
 aiofiles==23.2.1
-jinja2==3.1.3
+jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.31.0
 


### PR DESCRIPTION
**Note:** The `APP_VERSION` was not correctly incremented with version 2.9.1 and has been corrected with this release.

## Component Changes

- Upgrade Jinja2 from 3.1.3 to 3.1.4