### PR TITLE
Add support for Umami web analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Ruff
+.ruff_cache
+
 # Distribution / packaging
 .Python
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changes
 
+## 2.11.0
+
+### Application Changes
+
+- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:
+
+| Config Key | Description |
+| ---------- | ----------- |
+| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
+| `url` | URL of the Umami analytics script |
+| `data_website_id` | Umami Site ID |
+| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
+| `data_host_url` | Override the location where Umami data is sent to |
+| `data_domains` | Comma-delimited list of domains where the Umami script should be active |
+
+### Component Changes
+
+- Upgrade wwdtm 2.10.0 to 2.10.1
+
+### Development Changes
+
+- Upgrade ruff from 0.3.6 to 0.5.1
+- Upgrade black from 24.3.0 to 24.4.2
+- Upgrade pytest from 8.1.1 to 8.1.2
+
 ## 2.10.0.post2
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.10.0.post2"
+APP_VERSION = "2.11.0"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,8 @@ from app.routers import (
     version,
 )
 
+from .utility import format_umami_analytics
+
 app = FastAPI(
     title=app_metadata["title"],
     description=app_metadata["description"],
@@ -59,6 +61,10 @@ async def default_page(request: Request):
         github_sponsor_url: str | None = settings.get("github_sponsor_url", None)
     else:
         stats_url = None
+
+    umami = config["settings"].get("umami_analytics")
+    umami_analytics = format_umami_analytics(umami_analytics=umami)
+
     return templates.TemplateResponse(
         "index.html",
         {
@@ -66,6 +72,7 @@ async def default_page(request: Request):
             "stats_url": stats_url,
             "patreon_url": patreon_url,
             "github_sponsor_url": github_sponsor_url,
+            "umami_analytics": umami_analytics,
         },
     )
 

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2018-2024 Linh Pham
+# api.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Utility functions used by api.wwdt.me."""
+
+
+def format_umami_analytics(umami_analytics: dict = None) -> str:
+    """Return formatted string for Umami Analytics."""
+    if not umami_analytics:
+        return None
+
+    _enabled = bool(umami_analytics.get("_enabled", False))
+
+    if not _enabled:
+        return None
+
+    url = umami_analytics.get("url")
+    website_id = umami_analytics.get("data_website_id")
+    auto_track = bool(umami_analytics.get("data_auto_track", True))
+    host_url = umami_analytics.get("data_host_url")
+    domains = umami_analytics.get("data_domains")
+
+    if url and website_id:
+        host_url_prop = f'data-host-url="{host_url}"' if host_url else ""
+        auto_track_prop = f'data-auto-track="{str(auto_track).lower()}"'
+        domains_prop = f'data-domains="{domains}"' if domains else ""
+
+        props = " ".join([host_url_prop, auto_track_prop, domains_prop])
+        return f'<script defer src="{url}" data-website-id="{website_id}" {props.strip()}></script>'
+
+    return None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-ruff==0.3.6
-black==24.3.0
-pytest==8.1.1
+ruff==0.5.1
+black==24.4.2
+pytest==8.1.2
 
 pydantic==2.7.0
 fastapi==0.110.2
@@ -12,4 +12,4 @@ jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.32.3
 
-wwdtm==2.10.0
+wwdtm==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.32.3
 
-wwdtm==2.10.0
+wwdtm==2.10.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
+
+    {% if umami_analytics -%}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}
 </head>
 
 <body>


### PR DESCRIPTION
## Application Changes

- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:

| Config Key | Description |
| ---------- | ----------- |
| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
| `url` | URL of the Umami analytics script |
| `data_website_id` | Umami Site ID |
| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
| `data_host_url` | Override the location where Umami data is sent to |
| `data_domains` | Comma-delimited list of domains where the Umami script should be active |

## Component Changes

- Upgrade wwdtm 2.10.0 to 2.10.1

## Development Changes

- Upgrade ruff from 0.3.6 to 0.5.1
- Upgrade black from 24.3.0 to 24.4.2
- Upgrade pytest from 8.1.1 to 8.1.2