### PR TITLE
Bumping dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2.12.0
+
+### Component Changes
+
+- Upgrade pydantic from 2.5.3 to 2.8.2
+- Upgrade fastapi from 0.109.1 to 0.112.0
+- Upgrade uvicorn from 0.26.0 to 0.30.5
+- Upgrade gunicorn from 22.0.0 to 23.0.0
+- Upgrade httpx from 0.26.0 to 0.27.0
+- Upgrade aiofiles from 23.2.1 to 24.1.0
+
+### Development Changes
+
+- Upgrade ruff from 0.5.1 to 0.5.7
+- Upgrade black from 24.4.2 to 24.8.0
+- Upgrade pytest from 8.1.2 to 8.3.2
+
 ## 2.11.0
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.11.0"
+APP_VERSION = "2.12.0"
 
 
 def load_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.black]
-required-version = "24.3.0"
+required-version = "24.8.0"
 target-version = ["py310", "py311", "py312"]
 line-length = 88
 
 [tool.pytest.ini_options]
-minversion = "7.4"
+minversion = "8.1"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,16 @@
-ruff==0.5.1
-black==24.4.2
-pytest==8.1.2
+ruff==0.5.7
+black==24.8.0
+pytest==8.3.2
 
-pydantic==2.7.0
-fastapi==0.110.2
-uvicorn[standard]==0.26.0
-gunicorn==22.0.0
-httpx==0.26.0
-aiofiles==23.2.1
+pydantic==2.8.2
+fastapi==0.112.0
+uvicorn[standard]==0.30.5
+gunicorn==23.0.0
+httpx==0.27.0
+aiofiles==24.1.0
 jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.32.3
 
 wwdtm==2.10.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-pydantic==2.5.3
-fastapi==0.109.1
-uvicorn[standard]==0.26.0
-gunicorn==22.0.0
-httpx==0.26.0
-aiofiles==23.2.1
+pydantic==2.8.2
+fastapi==0.112.0
+uvicorn[standard]==0.30.5
+gunicorn==23.0.0
+httpx==0.27.0
+aiofiles==24.1.0
 jinja2==3.1.4
 email-validator==2.1.0.post1
 requests==2.32.3


### PR DESCRIPTION
## Component Changes

- Upgrade pydantic from 2.5.3 to 2.8.2
- Upgrade fastapi from 0.109.1 to 0.112.0
- Upgrade uvicorn from 0.26.0 to 0.30.5
- Upgrade gunicorn from 22.0.0 to 23.0.0
- Upgrade httpx from 0.26.0 to 0.27.0
- Upgrade aiofiles from 23.2.1 to 24.1.0

## Development Changes

- Upgrade ruff from 0.5.1 to 0.5.7
- Upgrade black from 24.4.2 to 24.8.0
- Upgrade pytest from 8.1.2 to 8.3.2