### PR TITLE
Adding Best Of, Repeat Best Of and Repeat Show endpoints, Add missing fields to models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changes
 
+## 2.15.0
+
+### Application Changes
+
+- Add `/v2.0/shows/best-ofs` endpoint that provides information for all Best Of shows
+- Add `/v2.0/shows/details/best-ofs` endpoint that provides detailed information for all Best Of shows
+- Add `/v2.0/shows/best-of-repeats` endpoint that provides information for all Best Of Repeat shows
+- Add `/v2.0/shows/details/best-of-repeats` endpoint that provides detailed information for all Best Of Repeat shows
+- Add `/v2.0/shows/repeats` endpoint that provides information for all Repeat shows
+- Add `/v2.0/shows/details/repeats/` endpoint that provides detailed information for all Repeat shows
+- Add missing `original_show_id` and `original_show_date` for `Show`, `ShowDetails`, `Shows` and `ShowsDetails` models
+
+### Component Changes
+
+- Upgrade wwdtm from 2.12.1.post0 to 2.14.0
+  - **Note:** Even though wwdtm version >= 2.13.0 has initial support for Python 3.13, FastAPI has not been validated against Python 3.13; thus, api.wwdt.me_v2 still only supports Python 3.10, 3.11 and 3.12.
+
+### Development Changes
+
+- Upgrade black from 24.8.0 to 24.10.0
+- Upgrade ruff from 0.6.9 to 0.7.0
+- Increase minimum pytest version from 8.0 to 8.3 in `pyproject.toml`
+- Add missing validation of `original_show_id` and `original_show_date` in endpoints that return `Show`, `ShowDetails`, `Shows` and `ShowsDetails` models
+
 ## 2.14.0
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Add `/v2.0/shows/best-ofs` endpoint that provides information for all Best Of shows
 - Add `/v2.0/shows/details/best-ofs` endpoint that provides detailed information for all Best Of shows
-- Add `/v2.0/shows/best-of-repeats` endpoint that provides information for all Best Of Repeat shows
-- Add `/v2.0/shows/details/best-of-repeats` endpoint that provides detailed information for all Best Of Repeat shows
+- Add `/v2.0/shows/repeat-best-ofs` endpoint that provides information for all Repeat Best Of shows
+- Add `/v2.0/shows/details/repeat-best-ofs` endpoint that provides detailed information for all Repeat Best Of shows
 - Add `/v2.0/shows/repeats` endpoint that provides information for all Repeat shows
 - Add `/v2.0/shows/details/repeats/` endpoint that provides detailed information for all Repeat shows
 - Add missing `original_show_id` and `original_show_date` for `Show`, `ShowDetails`, `Shows` and `ShowsDetails` models

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note that version 1.0 of the Stats API has now been deprecated.
 
 ## Requirements
 
-- Python 3.10 or newer
+- Python 3.10 through 3.12. Python 3.13 is currently not validated.
 - MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Changes from v1.0

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.14.0"
+APP_VERSION = "2.15.0"
 
 
 def load_config(

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -19,6 +19,9 @@ class Show(BaseModel):
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Best Of Show")
     show_url: str | None = Field(default=None, title="URL for Show Page on NPR.org")
+    original_show_id: Annotated[int, Field(ge=0, lt=2**31)] | None = \
+        Field(default=None, title="Original Show ID")
+    original_show_date: str | None = Field(default=None, title="Original Show Date")
 
 
 class Shows(BaseModel):

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -55,8 +55,38 @@ async def get_shows():
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while retrieving "
-            "shows from the database",
+            detail="Database error occurred while retrieving shows from the database",
+        ) from None
+
+
+@router.get(
+    "/best-ofs",
+    summary="Retrieve Information for All Best Of Shows",
+    response_model=ModelsShows,
+    tags=["Shows"],
+)
+@router.head("/best-ofs", include_in_schema=False)
+async def get_best_ofs():
+    """Retrieve all Best Of Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_all_best_ofs()
+        if show_info:
+            return {"shows": show_info}
+
+        raise HTTPException(status_code=404, detail="No Best Of shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve Best Of shows from the database"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Best Of shows from the database",
         ) from None
 
 
@@ -375,6 +405,78 @@ async def get_shows_details():
 
 
 @router.get(
+    "/details/best-ofs",
+    summary="Retrieve Detailed Information for All Best Of Shows",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/best-ofs", include_in_schema=False)
+async def get_details_best_ofs():
+    """Retrieve all Best Of Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_all_best_ofs_details()
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail="No Best Of shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve Best Of shows from the database"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Best Of shows from the database",
+        ) from None
+
+
+@router.get(
+    "/details/id/{show_id}",
+    summary="Retrieve Detailed Information by Show ID",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/id/{show_id}", include_in_schema=False)
+async def get_show_details_by_id(
+    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
+):
+    """Retrieve Details for a Shows by Show ID.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    NPR.org show URL, location, description, notes, host, scorekeeper,
+    panelists, Bluff information and Not My Job guests
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_details_by_id(
+            show_id, include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail=f"Show ID {show_id} not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail=f"Show ID {show_id} not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
     "/details/date/iso/{show_date}",
     summary="Retrieve Detailed Information for Shows by Year, Month, and Day using ISO format date",
     response_model=ModelsShowDetails,
@@ -606,47 +708,6 @@ async def get_show_details_by_date(
 
 
 @router.get(
-    "/details/id/{show_id}",
-    summary="Retrieve Detailed Information by Show ID",
-    response_model=ModelsShowDetails,
-    tags=["Shows"],
-)
-@router.head("/details/id/{show_id}", include_in_schema=False)
-async def get_show_details_by_id(
-    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
-):
-    """Retrieve Details for a Shows by Show ID.
-
-    Return data: Show ID, date, Best Of flag, Repeat flag or date,
-    NPR.org show URL, location, description, notes, host, scorekeeper,
-    panelists, Bluff information and Not My Job guests
-    """
-    try:
-        show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_id(
-            show_id, include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
-        if show_details:
-            return show_details
-
-        raise HTTPException(status_code=404, detail=f"Show ID {show_id} not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Show ID {show_id} not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500,
-            detail="Unable to retrieve show information from the database",
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while retrieving show information from the database",
-        ) from None
-
-
-@router.get(
     "/details/recent",
     summary="Retrieve Detailed Information for Recent Shows",
     response_model=ModelsShowsDetails,
@@ -683,6 +744,71 @@ async def get_shows_recent_details():
 
 
 @router.get(
+    "/details/repeat-best-ofs",
+    summary="Retrieve Detailed Information for All Repeat Best Of Shows",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/repeat-best-ofs", include_in_schema=False)
+async def get_details_repeat_best_ofs():
+    """Retrieve all Repeat Best Of Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_all_repeat_best_ofs_details()
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail="No Repeat Best Of shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve Repeat Best Of shows from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Repeat Best Of shows from "
+            "the database",
+        ) from None
+
+
+@router.get(
+    "/details/repeats",
+    summary="Retrieve Detailed Information for All Repeat Shows",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/repeats", include_in_schema=False)
+async def get_details_repeats():
+    """Retrieve all Repeat Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_all_repeats_details()
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail="No Repeat shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve Repeat shows from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Repeat shows from the database",
+        ) from None
+
+
+@router.get(
     "/recent",
     summary="Retrieve Information for Recent Shows",
     response_model=ModelsShows,
@@ -712,4 +838,68 @@ async def get_shows_recent():
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while retrieving shows from the database",
+        ) from None
+
+
+@router.get(
+    "/repeats",
+    summary="Retrieve Information for All Repeat Shows",
+    response_model=ModelsShows,
+    tags=["Shows"],
+)
+@router.head("/repeats", include_in_schema=False)
+async def get_repeats():
+    """Retrieve all Repeat Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_all_repeats()
+        if show_info:
+            return {"shows": show_info}
+
+        raise HTTPException(status_code=404, detail="No Repeat shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve Repeat shows from the database"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Repeat shows from the database",
+        ) from None
+
+
+@router.get(
+    "/repeat-best-ofs",
+    summary="Retrieve Information for All Repeat Best Of Shows",
+    response_model=ModelsShows,
+    tags=["Shows"],
+)
+@router.head("/repeat-best-ofs", include_in_schema=False)
+async def get_repeat_best_ofs():
+    """Retrieve all Repeat Best Of Shows.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and  NPR.org
+    show url
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_all_repeat_best_ofs()
+        if show_info:
+            return {"shows": show_info}
+
+        raise HTTPException(status_code=404, detail="No Repeat Best Of shows found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve Repeat Best Of shows from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving Repeat Best Of shows "
+            "from the database",
         ) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.black]
-required-version = "24.8.0"
+required-version = "24.10.0"
 target-version = ["py310", "py311", "py312"]
 line-length = 88
 
 [tool.pytest.ini_options]
-minversion = "8.0"
+minversion = "8.3"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-ruff==0.6.9
-black==24.8.0
+ruff==0.7.0
+black==24.10.0
 pytest==8.3.3
 pytest-cov==5.0.0
 
@@ -13,5 +13,4 @@ jinja2==3.1.4
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.12.1.post0
-
+wwdtm==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.4
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.12.1.post0
+wwdtm==2.14.0

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -41,6 +41,25 @@ def test_shows_id(show_id: int):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+
+
+def test_shows_best_ofs():
+    """Test /v2.0/shows/best-ofs route."""
+    response = client.get(f"/v{API_VERSION}/shows/best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
@@ -56,6 +75,8 @@ def test_shows_date_iso_show_date(show_date: str):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
 
 
 @pytest.mark.parametrize("year", [2006])
@@ -73,6 +94,8 @@ def test_shows_date_year(year: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("year, month", [(2006, 6)])
@@ -90,6 +113,8 @@ def test_shows_date_year_month(year: int, month: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("month, day", [(10, 27)])
@@ -107,6 +132,8 @@ def test_shows_date_month_day(month: int, day: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
 
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
@@ -123,6 +150,8 @@ def test_shows_date_year_month_day(year: int, month: int, day: int):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
 
 
 def test_show_dates():
@@ -147,6 +176,8 @@ def test_shows_details():
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -168,6 +199,8 @@ def test_shows_details_date_iso_show_date(show_date: str):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -191,6 +224,8 @@ def test_shows_details_date_year(year: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -214,6 +249,8 @@ def test_shows_details_date_year_month(year: int, month: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -237,6 +274,8 @@ def test_shows_details_date_month_day(month: int, day: int):
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -259,6 +298,8 @@ def test_shows_details_date_year_month_day(year: int, month: int, day: int):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -280,6 +321,8 @@ def test_shows_details_id(show_id: int):
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
     assert "location" in show
     assert "description" in show
     assert "host" in show
@@ -300,6 +343,8 @@ def test_shows_details_recent():
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
     assert "location" in shows["shows"][0]
     assert "description" in shows["shows"][0]
     assert "host" in shows["shows"][0]
@@ -320,3 +365,44 @@ def test_shows_recent():
     assert "best_of" in shows["shows"][0]
     assert "repeat_show" in shows["shows"][0]
     assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
+def test_shows_repeat_best_ofs():
+    """Test /v2.0/shows/repeat-best-ofs route."""
+    response = client.get(f"/v{API_VERSION}/shows/repeat-best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)
+
+
+def test_shows_repeats():
+    """Test /v2.0/shows/repeats route."""
+    response = client.get(f"/v{API_VERSION}/shows/repeats")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)


### PR DESCRIPTION
### Application Changes

- Add `/v2.0/shows/best-ofs` endpoint that provides information for all Best Of shows
- Add `/v2.0/shows/details/best-ofs` endpoint that provides detailed information for all Best Of shows
- Add `/v2.0/shows/repeat-best-ofs` endpoint that provides information for all Repeat Best Of shows
- Add `/v2.0/shows/details/repeat-best-ofs` endpoint that provides detailed information for all Repeat Best Of shows
- Add `/v2.0/shows/repeats` endpoint that provides information for all Repeat shows
- Add `/v2.0/shows/details/repeats/` endpoint that provides detailed information for all Repeat shows
- Add missing `original_show_id` and `original_show_date` for `Show`, `ShowDetails`, `Shows` and `ShowsDetails` models

### Component Changes

- Upgrade wwdtm from 2.12.1.post0 to 2.14.0
  - **Note:** Even though wwdtm version >= 2.13.0 has initial support for Python 3.13, FastAPI has not been validated against Python 3.13; thus, api.wwdt.me_v2 still only supports Python 3.10, 3.11 and 3.12.

### Development Changes

- Upgrade black from 24.8.0 to 24.10.0
- Upgrade ruff from 0.6.9 to 0.7.0
- Increase minimum pytest version from 8.0 to 8.3 in `pyproject.toml`
- Add missing validation of `original_show_id` and `original_show_date` in endpoints that return `Show`, `ShowDetails`, `Shows` and `ShowsDetails` models