### PR TITLE
Bump Jinja2 version, update copyright dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.15.1
+
+### Component Changes
+
+- Upgrade jinja2 from 3.1.4 to 3.1.5
+
 ## 2.15.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changes
 
-## 2.15.1
-
-### Component Changes
-
-- Upgrade jinja2 from 3.1.4 to 3.1.5
-
 ## 2.15.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.15.0"
+APP_VERSION = "2.15.1"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/guests.py
+++ b/app/models/guests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/pronouns.py
+++ b/app/models/pronouns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/models/version.py
+++ b/app/models/version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/pronouns.py
+++ b/app/routers/pronouns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ uvicorn[standard]==0.30.6
 gunicorn==23.0.0
 httpx==0.27.2
 aiofiles==24.1.0
-jinja2==3.1.4
+jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ uvicorn[standard]==0.30.6
 gunicorn==23.0.0
 httpx==0.27.2
 aiofiles==24.1.0
-jinja2==3.1.5
+jinja2==3.1.4
 email-validator==2.2.0
 requests==2.32.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.30.6
 gunicorn==23.0.0
 httpx==0.27.2
 aiofiles==24.1.0
-jinja2==3.1.4
+jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # api.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## Component Changes

- Upgrade jinja2 from 3.1.4 to 3.1.5