### PR TITLE
Fix issue where locations are not included in state value is not set, code formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
             "source.fixAll": "explicit",
             "source.sortImports": "explicit",
         },
-        "editor.defaultFormatter": "ms-python.black-formatter"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2.15.2
+
+### Application Changes
+
+- Add missing `patreon_url` and `github_sponsor_url` variable initialization for appropriate codepaths
+- Fix issue where locations with a null value for state aren't listed in various `locations` API endpoint responses
+
+### Component Changes
+
+- Upgrade wwdtm from 2.14.0 to 2.15.0
+
+### Development Changes
+
+- Upgrade ruff from 0.9.2 to 0.9.3
+- Remove black from required development packages as part of migrating entirely to Ruff
+- Ran `ruff format` to format Python code files using the Ruff 2025 Style Guide
+
 ## 2.15.1
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.15.1"
+APP_VERSION = "2.15.2"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,8 @@ async def default_page(request: Request):
         github_sponsor_url: str | None = settings.get("github_sponsor_url", None)
     else:
         stats_url = None
+        patreon_url = None
+        github_sponsor_url = None
 
     umami = config["settings"].get("umami_analytics")
     umami_analytics = format_umami_analytics(umami_analytics=umami)

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -19,8 +19,9 @@ class Show(BaseModel):
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Best Of Show")
     show_url: str | None = Field(default=None, title="URL for Show Page on NPR.org")
-    original_show_id: Annotated[int, Field(ge=0, lt=2**31)] | None = \
-        Field(default=None, title="Original Show ID")
+    original_show_id: Annotated[int, Field(ge=0, lt=2**31)] | None = Field(
+        default=None, title="Original Show ID"
+    )
     original_show_date: str | None = Field(default=None, title="Original Show Date")
 
 

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -64,7 +64,7 @@ async def get_guests():
 )
 @router.head("/id/{guest_id}", include_in_schema=False)
 async def get_guest_by_id(
-    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
+    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)],
 ):
     """Retrieve a Not My Job Guest by Guest ID.
 
@@ -100,7 +100,7 @@ async def get_guest_by_id(
 )
 @router.head("/slug/{guest_slug}", include_in_schema=False)
 async def get_guest_by_slug(
-    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")],
 ):
     """Retrieve a Not My Job Guest by Guest Slug String.
 
@@ -170,7 +170,7 @@ async def get_guests_details():
 )
 @router.head("/details/id/{guest_id}", include_in_schema=False)
 async def get_guest_details_by_id(
-    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)]
+    guest_id: Annotated[int, Path(title="The ID of the guest to get", ge=0, lt=2**31)],
 ):
     """Retrieve Details for a Not My Job Guest by Guest ID.
 
@@ -208,7 +208,7 @@ async def get_guest_details_by_id(
 )
 @router.head("/details/slug/{guest_slug}", include_in_schema=False)
 async def get_guest_details_by_slug(
-    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+    guest_slug: Annotated[str, Path(title="The slug string of the guest to get")],
 ):
     """Retrieve Details for a Not My Job Guest by Guest Slug String.
 

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -64,7 +64,7 @@ async def get_hosts():
 )
 @router.head("/id/{host_id}", include_in_schema=False)
 async def get_host_by_id(
-    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
+    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)],
 ):
     """Retrieve a Host by Host ID.
 
@@ -100,7 +100,7 @@ async def get_host_by_id(
 )
 @router.head("/slug/{host_slug}", include_in_schema=False)
 async def get_host_by_slug(
-    host_slug: Annotated[str, Path(title="The slug string of the host to get")]
+    host_slug: Annotated[str, Path(title="The slug string of the host to get")],
 ):
     """Retrieve a Host by Host Slug String.
 
@@ -170,7 +170,7 @@ async def get_hosts_details():
 )
 @router.head("/details/id/{host_id}", include_in_schema=False)
 async def get_host_details_by_id(
-    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)]
+    host_id: Annotated[int, Path(title="The ID of the host to get", ge=0, lt=2**31)],
 ):
     """Retrieve Details for a Host by Host ID.
 
@@ -208,7 +208,7 @@ async def get_host_details_by_id(
 )
 @router.head("/details/slug/{host_slug}", include_in_schema=False)
 async def get_host_details_by_slug(
-    host_slug: Annotated[str, Path(title="The slug string of the guest to get")]
+    host_slug: Annotated[str, Path(title="The slug string of the guest to get")],
 ):
     """Retrieve Details for a Host by Host Slug String.
 

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -66,7 +66,7 @@ async def get_locations():
 async def get_location_by_id(
     location_id: Annotated[
         int, Path(title="The ID of the location to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve a Show Location by Location ID.
 
@@ -104,7 +104,7 @@ async def get_location_by_id(
 )
 @router.head("/slug/{location_slug}", include_in_schema=False)
 async def get_location_by_slug(
-    location_slug: Annotated[str, Path(title="The slug string of the location to get")]
+    location_slug: Annotated[str, Path(title="The slug string of the location to get")],
 ):
     """Retrieve a Show Location by Location Slug String.
 
@@ -179,7 +179,7 @@ async def get_locations_details():
 async def get_location_recordings_by_id(
     location_id: Annotated[
         int, Path(title="The ID of the location to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Details for a Show Location by Location ID.
 
@@ -221,7 +221,7 @@ async def get_location_recordings_by_id(
 )
 @router.head("/recordings/slug/{location_slug}", include_in_schema=False)
 async def get_location_recordings_by_slug(
-    location_slug: Annotated[str, Path(title="The slug string of the location to get")]
+    location_slug: Annotated[str, Path(title="The slug string of the location to get")],
 ):
     """Retrieve Details for a Show Location by Location Slug String.
 

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -73,7 +73,7 @@ async def get_panelists():
 async def get_panelist_by_id(
     panelist_id: Annotated[
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve a Panelist by Panelist ID.
 
@@ -111,7 +111,7 @@ async def get_panelist_by_id(
 )
 @router.head("/slug/{panelist_slug}", include_in_schema=False)
 async def get_panelist_by_slug(
-    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")],
 ):
     """Retrieve a Panelist by Panelist Slug String.
 
@@ -188,7 +188,7 @@ async def get_panelists_details():
 async def get_panelist_details_by_id(
     panelist_id: Annotated[
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Details for a Panelist by Panelist ID.
 
@@ -231,7 +231,7 @@ async def get_panelist_details_by_id(
 )
 @router.head("/details/slug/{panelist_slug}", include_in_schema=False)
 async def get_panelist_details_by_slug(
-    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")],
 ):
     """Retrieve Details for a Panelist by Panelist Slug String.
 
@@ -278,7 +278,7 @@ async def get_panelist_details_by_slug(
 async def get_panelist_scores_by_id(
     panelist_id: Annotated[
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Panelist Scores by Panelist ID.
 
@@ -325,7 +325,7 @@ async def get_panelist_scores_by_id(
 )
 @router.head("/scores/slug/{panelist_slug}", include_in_schema=False)
 async def get_panelist_scores_by_slug(
-    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")],
 ):
     """Retrieve Panelist Scores by Panelist Slug String.
 
@@ -375,7 +375,7 @@ async def get_panelist_scores_by_slug(
 async def get_panelist_scores_grouped_ordered_pair_by_id(
     panelist_id: Annotated[
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Panelist Grouped Scores by Panelist ID.
 
@@ -430,7 +430,7 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
     "/scores/grouped-ordered-pair/slug/{panelist_slug}", include_in_schema=False
 )
 async def get_panelist_scores_grouped_ordered_pair_by_slug(
-    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")],
 ):
     """Retrieve Panelist Grouped Scores by Panelist Slug String.
 
@@ -482,7 +482,7 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
 async def get_panelist_scores_ordered_pair_by_id(
     panelist_id: Annotated[
         int, Path(title="The ID of the panelist to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Panelist Scores as Ordered Pairs by Panelist ID.
 
@@ -516,8 +516,7 @@ async def get_panelist_scores_ordered_pair_by_id(
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve panelist scores",
+            detail="Database error occurred while trying to retrieve panelist scores",
         ) from None
 
 
@@ -529,7 +528,7 @@ async def get_panelist_scores_ordered_pair_by_id(
 )
 @router.head("/scores/ordered-pair/slug/{panelist_slug}", include_in_schema=False)
 async def get_panelist_scores_ordered_pair_by_slug(
-    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")]
+    panelist_slug: Annotated[str, Path(title="The slug string of the panelist to get")],
 ):
     """Retrieve Panelist Scores as Ordered Pairs by Panelist Slug String.
 

--- a/app/routers/pronouns.py
+++ b/app/routers/pronouns.py
@@ -64,7 +64,7 @@ async def get_pronouns():
 async def get_pronouns_by_id(
     pronouns_id: Annotated[
         int, Path(title="The ID of the pronouns to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve a Pronouns String by Pronouns ID.
 

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -66,7 +66,7 @@ async def get_scorekeepers():
 async def get_scorekeeper_by_id(
     scorekeeper_id: Annotated[
         int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve a Scorekeeper by Scorekeeper ID.
 
@@ -106,7 +106,7 @@ async def get_scorekeeper_by_id(
 async def get_scorekeeper_by_slug(
     scorekeeper_slug: Annotated[
         str, Path(title="The slug string of the scorekeeper to get")
-    ]
+    ],
 ):
     """Retrieve a Scorekeeper by Scorekeeper Slug String.
 
@@ -182,7 +182,7 @@ async def get_scorekeepers_details():
 async def get_scorekeeper_details_by_id(
     scorekeeper_id: Annotated[
         int, Path(title="The ID of the scorekeeper to get", ge=0, lt=2**31)
-    ]
+    ],
 ):
     """Retrieve Details for a Scorekeeper by Scorekeeper ID.
 
@@ -225,7 +225,7 @@ async def get_scorekeeper_details_by_id(
 async def get_scorekeeper_details_by_slug(
     scorekeeper_slug: Annotated[
         str, Path(title="The slug string of the scorekeeper to get")
-    ]
+    ],
 ):
     """Retrieve Details for a Scorekeeper by Scorekeeper ID.
 

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -98,7 +98,7 @@ async def get_best_ofs():
 )
 @router.head("/id/{show_id}", include_in_schema=False)
 async def get_show_by_id(
-    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
+    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)],
 ):
     """Retrieve a Show by Show ID.
 
@@ -136,7 +136,7 @@ async def get_show_by_id(
 )
 @router.head("/date/iso/{show_date}", include_in_schema=False)
 async def get_show_by_date_string(
-    show_date: Annotated[date, Path(title="ISO date for the show to get")]
+    show_date: Annotated[date, Path(title="ISO date for the show to get")],
 ):
     """Retrieve a Show by Show Date in YYYY-MM-DD format.
 
@@ -174,7 +174,7 @@ async def get_show_by_date_string(
 )
 @router.head("/date/{year}", include_in_schema=False)
 async def get_shows_by_year(
-    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
 ):
     """Retrieve All Shows by Year.
 
@@ -443,7 +443,7 @@ async def get_details_best_ofs():
 )
 @router.head("/details/id/{show_id}", include_in_schema=False)
 async def get_show_details_by_id(
-    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)]
+    show_id: Annotated[int, Path(title="The ID of the show to get", ge=0, lt=2**31)],
 ):
     """Retrieve Details for a Shows by Show ID.
 
@@ -484,7 +484,7 @@ async def get_show_details_by_id(
 )
 @router.head("/details/date/iso/{show_date}", include_in_schema=False)
 async def get_show_details_by_date_string(
-    show_date: Annotated[date, Path(title="ISO date for the show to get")]
+    show_date: Annotated[date, Path(title="ISO date for the show to get")],
 ):
     """Retrieve Details for a Show by Show Date in YYYY-MM-DD format.
 
@@ -526,7 +526,7 @@ async def get_show_details_by_date_string(
 )
 @router.head("/details/date/{year}", include_in_schema=False)
 async def get_shows_details_by_year(
-    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)]
+    year: Annotated[int, Path(title="The year to get shows for", ge=1998, le=9999)],
 ):
     """Retrieve Details for Shows by Year.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-required-version = "24.10.0"
-target-version = ["py310", "py311", "py312"]
-line-length = 88
-
 [tool.pytest.ini_options]
 minversion = "8.3"
 filterwarnings = [
@@ -17,6 +12,7 @@ norecursedirs = [
 ]
 
 [tool.ruff]
+required-version = ">= 0.9.0"
 target-version = "py310"
 
 exclude = [
@@ -30,7 +26,7 @@ exclude = [
     ".venv",
 ]
 
-line-length = 88 # Must agree with Black
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-ruff==0.7.0
-black==24.10.0
+ruff==0.9.3
 pytest==8.3.3
 pytest-cov==5.0.0
 
@@ -13,4 +12,4 @@ jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.14.0
+wwdtm==2.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.14.0
+wwdtm==2.15.0

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -31,7 +31,7 @@ def test_locations():
         assert "longitude" in locations["locations"][0]["coordinates"]
 
 
-@pytest.mark.parametrize("location_id", [32])
+@pytest.mark.parametrize("location_id", [32, 148])
 def test_locations_id(location_id: int):
     """Test /v2.0/locations/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/id/{location_id}")
@@ -50,7 +50,10 @@ def test_locations_id(location_id: int):
         assert "longitude" in location["coordinates"]
 
 
-@pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
+@pytest.mark.parametrize(
+    "location_slug",
+    ["arlene-schnitzer-concert-hall-portland-or", "home-remote-studios"],
+)
 def test_locations_slug(location_slug: str):
     """Test /v2.0/locations/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/slug/{location_slug}")
@@ -87,7 +90,7 @@ def test_locations_recordings():
     assert "recordings" in locations["locations"][0]
 
 
-@pytest.mark.parametrize("location_id", [32])
+@pytest.mark.parametrize("location_id", [32, 148])
 def test_locations_recordings_id(location_id: int):
     """Test /v2.0/locations/recordings/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/id/{location_id}")
@@ -106,7 +109,10 @@ def test_locations_recordings_id(location_id: int):
     assert "recordings" in location
 
 
-@pytest.mark.parametrize("location_slug", ["arlene-schnitzer-concert-hall-portland-or"])
+@pytest.mark.parametrize(
+    "location_slug",
+    ["arlene-schnitzer-concert-hall-portland-or", "home-remote-studios"],
+)
 def test_locations_recordings_slug(location_slug: str):
     """Test /v2.0/locations/recordings/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/slug/{location_slug}")


### PR DESCRIPTION
## Application Changes

- Add missing `patreon_url` and `github_sponsor_url` variable initialization for appropriate codepaths
- Fix issue where locations with a null value for state aren't listed in various `locations` API endpoint responses

## Component Changes

- Upgrade wwdtm from 2.14.0 to 2.15.0

## Development Changes

- Upgrade ruff from 0.9.2 to 0.9.3
- Remove black from required development packages as part of migrating entirely to Ruff
- Ran `ruff format` to format Python code files using the Ruff 2025 Style Guide