### PR TITLE
Adding random endpoints for all major sections, adding postal abbreviation endpoints

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGE CONTROL]
+exclude = R0901

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changes
 
+## 2.16.0
+
+### Application Changes
+
+- Add `/random`, `/random/details`, `/random/id`, and `/random/slug` endpoints to Guests, Hosts, Locations, Panelists and Scorekeepers to retrieve a random item, ID or slug string from the corresponding sections
+- Add `/random`, `/random/details`, `/random/id` and `/random/date` endpoints to Shows to retrieve a random show, ID or ISO-formatted date string
+- Add `/postal-abbreviations`, `/postal-abbreviations/details` and `/postal-abbreviations/details/{abbreviation}` endpoints to Locations to get a list of postal abbreviations, get details for all available postal abbreviations, and get details for a specific postal abbreviation
+- Add `PostalAbbreviationDetails`, `PostalAbbreviations` and `PostalAbbreviationsDetails` models for the above endpoints
+
+### Component Changes
+
+- Upgrade wwdtm from 2.15.0 to 2.16.1
+
+### Development Changes
+
+- Added tests for all of the new endpoints
+
 ## 2.15.2
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.15.2"
+APP_VERSION = "2.16.0"
 
 
 def load_config(

--- a/app/models/guests.py
+++ b/app/models/guests.py
@@ -66,3 +66,15 @@ class GuestsDetails(BaseModel):
 
     guests: list[GuestDetails] = Field(title="List of Guest Details")
     guests: list[GuestDetails] = Field(title="List of Guest Details")
+
+
+class GuestID(BaseModel):
+    """Not My Job Guest ID."""
+
+    id: int = Field(title="Guest ID")
+
+
+class GuestSlug(BaseModel):
+    """Not My Job Guest Slug String."""
+
+    slug: str = Field(title="Guest Slug String")

--- a/app/models/hosts.py
+++ b/app/models/hosts.py
@@ -67,3 +67,15 @@ class HostsDetails(BaseModel):
 
     hosts: list[HostDetails] = Field(title="List of Host Details")
     hosts: list[HostDetails] = Field(title="List of Host Details")
+
+
+class HostID(BaseModel):
+    """Host ID."""
+
+    id: int = Field(title="Host ID")
+
+
+class HostSlug(BaseModel):
+    """Host Slug String."""
+
+    slug: str = Field(title="Host Slug String")

--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -8,7 +8,7 @@
 from decimal import Decimal
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class LocationCoordinates(BaseModel):
@@ -78,4 +78,35 @@ class LocationsDetails(BaseModel):
     """List of Location Details."""
 
     locations: list[LocationDetails] = Field(title="List of Location Details")
-    locations: list[LocationDetails] = Field(title="List of Location Details")
+
+
+class LocationID(BaseModel):
+    """Location ID."""
+
+    id: int = Field(title="Location ID")
+
+
+class LocationSlug(BaseModel):
+    """Location Slug String."""
+
+    slug: str = Field(title="Location Slug String")
+
+
+class PostalAbbreviationDetails(BaseModel):
+    """Postal Abbreviation Details."""
+
+    postal_abbreviation: str = Field("Postal Abbreviation")
+    name: str = Field(title="State, Province or Territory Name")
+    country: str = Field(title="Country Name")
+
+
+class PostalAbbreviations(RootModel[list[str]]):
+    """List of Postal Abbreviations."""
+
+
+class PostalAbbreviationsDetails(BaseModel):
+    """List of Postal Abbreviations Details."""
+
+    postal_abbreviations: list[PostalAbbreviationDetails] = Field(
+        "List of Postal Abbreviations Details"
+    )

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -191,6 +191,18 @@ class PanelistsDetails(BaseModel):
     )
 
 
+class PanelistID(BaseModel):
+    """Panelist ID."""
+
+    id: int = Field(title="Panelist ID")
+
+
+class PanelistSlug(BaseModel):
+    """Panelist Slug String."""
+
+    slug: str = Field(title="Panelist Slug String")
+
+
 class PanelistScoresList(BaseModel):
     """List of Panelist Appearances as Show Dates and a list of corresponding Panelist scores."""
 

--- a/app/models/scorekeepers.py
+++ b/app/models/scorekeepers.py
@@ -70,3 +70,15 @@ class ScorekeepersDetails(BaseModel):
 
     scorekeepers: list[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")
     scorekeepers: list[ScorekeeperDetails] = Field(title="List of Scorekeeper Details")
+
+
+class ScorekeeperID(BaseModel):
+    """Scorekeeper ID."""
+
+    id: int = Field(title="Scorekeeper ID")
+
+
+class ScorekeeperSlug(BaseModel):
+    """Scorekeeper Slug String."""
+
+    slug: str = Field(title="Scorekeeper Slug String")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -60,6 +60,18 @@ class ShowHost(BaseModel):
     guest: bool = Field(title="Guest Host")
 
 
+class ShowID(BaseModel):
+    """Show ID."""
+
+    id: int = Field(title="Show ID")
+
+
+class ShowDate(BaseModel):
+    """Show Date String."""
+
+    date: str = Field(title="Show Date String")
+
+
 class ShowScorekeeper(BaseModel):
     """Show Scorekeeper Information."""
 

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -15,8 +15,10 @@ from wwdtm.guest import Guest
 from app.config import API_VERSION, load_config
 from app.models.guests import Guest as ModelsGuest
 from app.models.guests import GuestDetails as ModelsGuestDetails
+from app.models.guests import GuestID as ModelsGuestID
 from app.models.guests import Guests as ModelsGuests
 from app.models.guests import GuestsDetails as ModelsGuestsDetails
+from app.models.guests import GuestSlug as ModelsGuestSlug
 
 router = APIRouter(prefix=f"/v{API_VERSION}/guests")
 _config = load_config()
@@ -237,4 +239,140 @@ async def get_guest_details_by_slug(
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to retrieve guest information",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Not My Job Guest",
+    response_model=ModelsGuest,
+    tags=["Guests"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_guest():
+    """Retrieve a Random Not My Job Guest.
+
+    Returned data: Guest ID, name and slug string.
+    """
+    try:
+        guest = Guest(database_connection=_database_connection)
+        guest_info = guest.retrieve_random()
+        if guest_info:
+            return guest_info
+
+        raise HTTPException(status_code=404, detail="Random Guest not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Guest not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve guest information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Information and Appearances for a Random Not My Job Guest",
+    response_model=ModelsGuestDetails,
+    tags=["Guests"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_guest_details():
+    """Retrieve a Random Not My Job Guest.
+
+    Returned data: Guest ID, name, slug string, appearances and scores.
+
+    Appearances are sorted by date.
+    """
+    try:
+        guest = Guest(database_connection=_database_connection)
+        guest_details = guest.retrieve_random_details()
+        if guest_details:
+            return guest_details
+
+        raise HTTPException(status_code=404, detail="Random Guest not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Guest not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve guest information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Not My Job Guest ID",
+    response_model=ModelsGuestID,
+    tags=["Guests"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_guest_id():
+    """Retrieve a Random Not My Job Guest ID.
+
+    Returned data: Guest ID.
+    """
+    try:
+        guest = Guest(database_connection=_database_connection)
+        guest_id = guest.retrieve_random_id()
+        if guest_id:
+            return {"id": guest_id}
+
+        raise HTTPException(status_code=404, detail="Random Guest ID not returned")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Guest ID not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random guest ID"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random guest ID",
+        ) from None
+
+
+@router.get(
+    "/random/slug",
+    summary="Retrieve a Random Not My Job Guest Slug String",
+    response_model=ModelsGuestSlug,
+    tags=["Guests"],
+)
+@router.head("/random/slug", include_in_schema=False)
+async def get_random_guest_slug():
+    """Retrieve a Random Not My Job Guest Slug String.
+
+    Returned data: Guest slug string.
+    """
+    try:
+        guest = Guest(database_connection=_database_connection)
+        guest_slug = guest.retrieve_random_slug()
+        if guest_slug:
+            return {"slug": guest_slug}
+
+        raise HTTPException(
+            status_code=404, detail="Random Guest slug string not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Guest slug string not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random guest slug string"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random guest slug string",
         ) from None

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -15,8 +15,10 @@ from wwdtm.host import Host
 from app.config import API_VERSION, load_config
 from app.models.hosts import Host as ModelsHost
 from app.models.hosts import HostDetails as ModelsHostDetails
+from app.models.hosts import HostID as ModelsHostID
 from app.models.hosts import Hosts as ModelsHosts
 from app.models.hosts import HostsDetails as ModelsHostsDetails
+from app.models.hosts import HostSlug as ModelsHostSlug
 
 router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
 _config = load_config()
@@ -208,7 +210,7 @@ async def get_host_details_by_id(
 )
 @router.head("/details/slug/{host_slug}", include_in_schema=False)
 async def get_host_details_by_slug(
-    host_slug: Annotated[str, Path(title="The slug string of the guest to get")],
+    host_slug: Annotated[str, Path(title="The slug string of the host to get")],
 ):
     """Retrieve Details for a Host by Host Slug String.
 
@@ -237,4 +239,140 @@ async def get_host_details_by_slug(
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to retrieve host information",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Host",
+    response_model=ModelsHost,
+    tags=["Hosts"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_host():
+    """Retrieve a Random Host.
+
+    Returned data: Host ID, name, slug string and gender.
+    """
+    try:
+        host = Host(database_connection=_database_connection)
+        host_info = host.retrieve_random()
+        if host_info:
+            return host_info
+
+        raise HTTPException(status_code=404, detail="Random Host not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Host not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve host information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Information and Appearances for a Random Host",
+    response_model=ModelsHostDetails,
+    tags=["Hosts"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_host_details():
+    """Retrieve a Random Host.
+
+    Returned data: Host ID, name, slug string, gender, and appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        host = Host(database_connection=_database_connection)
+        host_details = host.retrieve_random_details()
+        if host_details:
+            return host_details
+
+        raise HTTPException(status_code=404, detail="Random Host not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Host not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve host information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Host ID",
+    response_model=ModelsHostID,
+    tags=["Hosts"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_host_id():
+    """Retrieve a Random Host ID.
+
+    Returned data: Host ID.
+    """
+    try:
+        host = Host(database_connection=_database_connection)
+        host_id = host.retrieve_random_id()
+        if host_id:
+            return {"id": host_id}
+
+        raise HTTPException(status_code=404, detail="Random Host ID not returned")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Host ID not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random host ID"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random host ID",
+        ) from None
+
+
+@router.get(
+    "/random/slug",
+    summary="Retrieve a Random Host Slug String",
+    response_model=ModelsHostSlug,
+    tags=["Hosts"],
+)
+@router.head("/random/slug", include_in_schema=False)
+async def get_random_host_slug():
+    """Retrieve a Random Host Slug String.
+
+    Returned data: Host slug string.
+    """
+    try:
+        host = Host(database_connection=_database_connection)
+        host_slug = host.retrieve_random_slug()
+        if host_slug:
+            return {"slug": host_slug}
+
+        raise HTTPException(
+            status_code=404, detail="Random Host slug string not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Host slug string not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random host slug string"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random host slug string",
         ) from None

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -15,8 +15,17 @@ from wwdtm.location import Location
 from app.config import API_VERSION, load_config
 from app.models.locations import Location as ModelsLocation
 from app.models.locations import LocationDetails as ModelsLocationDetails
+from app.models.locations import LocationID as ModelsLocationID
 from app.models.locations import Locations as ModelsLocations
 from app.models.locations import LocationsDetails as ModelsLocationsDetails
+from app.models.locations import LocationSlug as ModelsLocationSlug
+from app.models.locations import (
+    PostalAbbreviationDetails as ModelsPostalAbbreviationDetails,
+)
+from app.models.locations import PostalAbbreviations as ModelsPostalAbbreviations
+from app.models.locations import (
+    PostalAbbreviationsDetails as ModelsPostalAbbreviationsDetails,
+)
 
 router = APIRouter(prefix=f"/v{API_VERSION}/locations")
 _config = load_config()
@@ -208,8 +217,7 @@ async def get_location_recordings_by_id(
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve location information",
+            detail="Database error occurred while trying to retrieve location information",
         ) from None
 
 
@@ -251,6 +259,257 @@ async def get_location_recordings_by_slug(
     except DatabaseError:
         raise HTTPException(
             status_code=500,
-            detail="Database error occurred while trying to "
-            "retrieve location information",
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
+
+
+@router.get(
+    "/postal-abbreviations",
+    summary="Retrieve Postal Abbreviations",
+    response_model=ModelsPostalAbbreviations,
+    tags=["Locations"],
+)
+@router.head("/postal-abbreviations", include_in_schema=False)
+async def get_postal_abbreviations() -> list[str]:
+    """Retrieve All Postal Abbreviations.
+
+    Returned data: Postal abbreviations for states, provinces and
+    territoies.
+
+    Postal abbreviations are sorted alphabetically.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        abbreviations = location.retrieve_postal_abbreviations()
+        if abbreviations:
+            return list(abbreviations.keys())
+
+        raise HTTPException(status_code=404, detail="No postal abbreviations found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve postal abbreviations"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve postal abbreviations",
+        ) from None
+
+
+@router.get(
+    "/postal-abbreviations/details",
+    summary="Retrieve Information for All Postal Abbreviations",
+    response_model=ModelsPostalAbbreviationsDetails,
+    tags=["Locations"],
+)
+@router.head("/postal-abbreviations/details", include_in_schema=False)
+async def get_postal_abbreviations_details() -> list[dict[str, str]]:
+    """Retrieve Details for all All Postal Abbreviations.
+
+    Returned data: Postal abbreviations for states, provinces and
+    territoies.
+
+    Postal abbreviations are sorted alphabetically.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        abbreviations = location.retrieve_postal_abbreviations_list()
+        if abbreviations:
+            return {"postal_abbreviations": abbreviations}
+
+        raise HTTPException(status_code=404, detail="No postal abbreviations found")
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve postal abbreviations"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve postal abbreviations",
+        ) from None
+
+
+@router.get(
+    "/postal-abbreviations/details/{abbreviation}",
+    summary="Retrieve Information for a Postal Abbreviation",
+    response_model=ModelsPostalAbbreviationDetails,
+    tags=["Locations"],
+)
+@router.head("/postal-abbreviations/details/{abbreviation}", include_in_schema=False)
+async def get_postal_abbreviation(
+    abbreviation: Annotated[
+        str, Path(title="Postal Abbreviation to retrieve information")
+    ],
+):
+    """Retrieve Details for a Postal Abbreviation.
+
+    Returned data: Postal abbreviation, name of the state, province or
+    territory, and country.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        info = location.retrieve_postal_details_by_abbreviation(
+            abbreviation=abbreviation
+        )
+        if info:
+            return info
+
+        raise HTTPException(
+            status_code=404,
+            detail=f"Postal abbreviation {abbreviation} not found",
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Postal abbreviation {abbreviation} not found",
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve postal abbreviation information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve postal "
+            "abbreviaton information",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Location",
+    response_model=ModelsLocation,
+    tags=["Locations"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_location():
+    """Retrieve a Random Location.
+
+    Returned data: Location ID, venue, city, state and slug string.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        location_info = location.retrieve_random()
+        if location_info:
+            return location_info
+
+        raise HTTPException(status_code=404, detail="Random Location not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Location not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve location information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Information and Appearances for a Random Location",
+    response_model=ModelsLocationDetails,
+    tags=["Locations"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_location_details():
+    """Retrieve a Random Location.
+
+    Returned data: Location ID, venue, city, state, slug string, and recordings.
+
+    Appearances are sorted by date.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        location_details = location.retrieve_random_details()
+        if location_details:
+            return location_details
+
+        raise HTTPException(status_code=404, detail="Random Location not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Location not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve location information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Location ID",
+    response_model=ModelsLocationID,
+    tags=["Locations"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_location_id():
+    """Retrieve a Random Location ID.
+
+    Returned data: Location ID.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        location_id = location.retrieve_random_id()
+        if location_id:
+            return {"id": location_id}
+
+        raise HTTPException(status_code=404, detail="Random Location ID not returned")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Location ID not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random location ID"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random location ID",
+        ) from None
+
+
+@router.get(
+    "/random/slug",
+    summary="Retrieve a Random Location Slug String",
+    response_model=ModelsLocationSlug,
+    tags=["Locations"],
+)
+@router.head("/random/slug", include_in_schema=False)
+async def get_random_location_slug():
+    """Retrieve a Random Location Slug String.
+
+    Returned data: Location slug string.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        location_slug = location.retrieve_random_slug()
+        if location_slug:
+            return {"slug": location_slug}
+
+        raise HTTPException(
+            status_code=404, detail="Random Location slug string not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Location slug string not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random location slug string"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a location host slug string",
         ) from None

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -15,6 +15,7 @@ from wwdtm.panelist import Panelist, PanelistDecimalScores, PanelistScores
 from app.config import API_VERSION, load_config
 from app.models.panelists import Panelist as ModelsPanelist
 from app.models.panelists import PanelistDetails as ModelsPanelistDetails
+from app.models.panelists import PanelistID as ModelsPanelistID
 from app.models.panelists import Panelists as ModelsPanelists
 from app.models.panelists import (
     PanelistScoresGroupedOrderedPair as ModelsPanelistScoresGroupedOrderedPair,
@@ -24,6 +25,7 @@ from app.models.panelists import (
     PanelistScoresOrderedPair as ModelsPanelistScoresOrderedPair,
 )
 from app.models.panelists import PanelistsDetails as ModelsPanelistsDetails
+from app.models.panelists import PanelistSlug as ModelsPanelistSlug
 
 router = APIRouter(prefix=f"/v{API_VERSION}/panelists")
 _config = load_config()
@@ -567,4 +569,145 @@ async def get_panelist_scores_ordered_pair_by_slug(
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to retrieve panelist scores",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Panelist",
+    response_model=ModelsPanelist,
+    tags=["Panelists"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_panelist():
+    """Retrieve a Random Panelist.
+
+    Returned data: Panelist ID, name, slug string and gender.
+    """
+    try:
+        panelist = Panelist(database_connection=_database_connection)
+        panelist_info = panelist.retrieve_random()
+        if panelist_info:
+            return panelist_info
+
+        raise HTTPException(status_code=404, detail="Random Panelist not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Panelist not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve panelist information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Information and Appearances for a Random Panelist",
+    response_model=ModelsPanelistDetails,
+    tags=["Panelists"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_panelist_details():
+    """Retrieve a Random Panelist.
+
+    Returned data: Panelist ID, name, slug string, gender, statistics
+    and appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        panelist = Panelist(database_connection=_database_connection)
+        panelist_details = panelist.retrieve_random_details()
+        if panelist_details:
+            return panelist_details
+
+        raise HTTPException(status_code=404, detail="Random Panelist not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Panelist not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve panelist information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Panelist ID",
+    response_model=ModelsPanelistID,
+    tags=["Panelists"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_panelist_id():
+    """Retrieve a Random Panelist ID.
+
+    Returned data: Panelist ID.
+    """
+    try:
+        panelist = Panelist(database_connection=_database_connection)
+        panelist_id = panelist.retrieve_random_id()
+        if panelist_id:
+            return {"id": panelist_id}
+
+        raise HTTPException(status_code=404, detail="Random Panelist ID not returned")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Panelist ID not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random panelist ID"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random panelist ID",
+        ) from None
+
+
+@router.get(
+    "/random/slug",
+    summary="Retrieve a Random Panelist Slug String",
+    response_model=ModelsPanelistSlug,
+    tags=["Panelists"],
+)
+@router.head("/random/slug", include_in_schema=False)
+async def get_random_panelist_slug():
+    """Retrieve a Random Panelist Slug String.
+
+    Returned data: Panelist slug string.
+    """
+    try:
+        panelist = Panelist(database_connection=_database_connection)
+        panelist_slug = panelist.retrieve_random_slug()
+        if panelist_slug:
+            return {"slug": panelist_slug}
+
+        raise HTTPException(
+            status_code=404, detail="Random Panelist slug string not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Panelist slug string not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random panelist slug string"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random panelist slug string",
         ) from None

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -15,8 +15,10 @@ from wwdtm.scorekeeper import Scorekeeper
 from app.config import API_VERSION, load_config
 from app.models.scorekeepers import Scorekeeper as ModelsScorekeeper
 from app.models.scorekeepers import ScorekeeperDetails as ModelsScorekeeperDetails
+from app.models.scorekeepers import ScorekeeperID as ModelsScorekeeperID
 from app.models.scorekeepers import Scorekeepers as ModelsScorekeepers
 from app.models.scorekeepers import ScorekeepersDetails as ModelsScorekeepersDetails
+from app.models.scorekeepers import ScorekeeperSlug as ModelsScorekeeperSlug
 
 router = APIRouter(prefix=f"/v{API_VERSION}/scorekeepers")
 _config = load_config()
@@ -259,4 +261,148 @@ async def get_scorekeeper_details_by_slug(
         raise HTTPException(
             status_code=500,
             detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Scorekeeper",
+    response_model=ModelsScorekeeper,
+    tags=["Scorekeepers"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_scorekeeper():
+    """Retrieve a Random Scorekeeper.
+
+    Returned data: Scorekeeper ID, name, slug string and gender.
+    """
+    try:
+        scorekeeper = Scorekeeper(database_connection=_database_connection)
+        scorekeeper_info = scorekeeper.retrieve_random()
+        if scorekeeper_info:
+            return scorekeeper_info
+
+        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve scorekeeper information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Information and Appearances for a Random Scorekeeper",
+    response_model=ModelsScorekeeperDetails,
+    tags=["Scorekeepers"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_scorekeeper_details():
+    """Retrieve a Random Scorekeeper.
+
+    Returned data: Scorekeeper ID, name, slug string, gender, and
+    appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        scorekeeper = Scorekeeper(database_connection=_database_connection)
+        scorekeeper_details = scorekeeper.retrieve_random_details()
+        if scorekeeper_details:
+            return scorekeeper_details
+
+        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve scorekeeper information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Scorekeeper ID",
+    response_model=ModelsScorekeeperID,
+    tags=["Scorekeepers"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_scorekeeper_id():
+    """Retrieve a Random Scorekeeper ID.
+
+    Returned data: Scorekeeper ID.
+    """
+    try:
+        scorekeeper = Scorekeeper(database_connection=_database_connection)
+        scorekeeper_id = scorekeeper.retrieve_random_id()
+        if scorekeeper_id:
+            return {"id": scorekeeper_id}
+
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper ID not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper ID not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve a random scorekeeper ID"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random scorekeeper ID",
+        ) from None
+
+
+@router.get(
+    "/random/slug",
+    summary="Retrieve a Random Scorekeeper Slug String",
+    response_model=ModelsScorekeeperSlug,
+    tags=["Scorekeepers"],
+)
+@router.head("/random/slug", include_in_schema=False)
+async def get_random_scorekeeper_slug():
+    """Retrieve a Random Scorekeeper Slug String.
+
+    Returned data: Scorekeeper slug string.
+    """
+    try:
+        scorekeeper = Scorekeeper(database_connection=_database_connection)
+        scorekeeper_slug = scorekeeper.retrieve_random_slug()
+        if scorekeeper_slug:
+            return {"slug": scorekeeper_slug}
+
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper slug string not returned"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper slug string not returned"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve a random scorekeeper slug string",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random scorekeeper slug string",
         ) from None

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -15,8 +15,10 @@ from wwdtm.show import Show
 
 from app.config import API_VERSION, load_config
 from app.models.shows import Show as ModelsShow
+from app.models.shows import ShowDate as ModelsShowDate
 from app.models.shows import ShowDates as ModelsShowDates
 from app.models.shows import ShowDetails as ModelsShowDetails
+from app.models.shows import ShowID as ModelsShowID
 from app.models.shows import Shows as ModelsShows
 from app.models.shows import ShowsDetails as ModelsShowsDetails
 
@@ -902,4 +904,143 @@ async def get_repeat_best_ofs():
             status_code=500,
             detail="Database error occurred while retrieving Repeat Best Of shows "
             "from the database",
+        ) from None
+
+
+@router.get(
+    "/random",
+    summary="Retrieve Information for a Random Show",
+    response_model=ModelsShow,
+    tags=["Shows"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_show():
+    """Retrieve Information for a Random Show.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and NPR.org
+    show URL
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_random()
+        if show_info:
+            return show_info
+
+        raise HTTPException(status_code=404, detail="Random Show not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Show not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
+    "/random/details",
+    summary="Retrieve Detailed Information for a Random Show",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/random/details", include_in_schema=False)
+async def get_random_show_details():
+    """Retrieve Details for a Random Show.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    NPR.org show URL, location, description, notes, host, scorekeeper,
+    panelists, Bluff information and Not My Job guests
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_random_details()
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail="Random Show not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Show not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Show ID",
+    response_model=ModelsShowID,
+    tags=["Shows"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_show_id():
+    """Retrieve a Random Show ID.
+
+    Returned data: Show ID.
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        _id = show.retrieve_random_id()
+        if _id:
+            return {"id": _id}
+
+        raise HTTPException(status_code=404, detail="Random Show ID not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Show ID not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve a random show ID",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random show ID",
+        ) from None
+
+
+@router.get(
+    "/random/date",
+    summary="Retrieve a Random Show Date",
+    response_model=ModelsShowDate,
+    tags=["Shows"],
+)
+@router.head("/random/date", include_in_schema=False)
+async def get_random_show_date():
+    """Retrieve a Random Show Date.
+
+    Returned data: Show Date.
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        _date = show.retrieve_random_date()
+        if _date:
+            return {"date": _date}
+
+        raise HTTPException(status_code=404, detail="Random Show Date not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Show Date not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve a random show date",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random show date",
         ) from None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.15.0
+wwdtm==2.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.15.0
+wwdtm==2.16.1

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -91,3 +91,46 @@ def test_guests_details_slug(guest_slug: str):
     assert "slug" in guest
     assert guest["slug"] == guest_slug
     assert "appearances" in guest
+
+
+def test_guests_random():
+    """Test /v2.0/guests/random route."""
+    response = client.get(f"/v{API_VERSION}/guests/random")
+    guest = response.json()
+
+    assert response.status_code == 200
+    assert "id" in guest
+    assert "name" in guest
+    assert "slug" in guest
+
+
+def test_guests_random_details():
+    """Test /v2.0/guests/random/details route."""
+    response = client.get(f"/v{API_VERSION}/guests/random/details")
+    guest = response.json()
+
+    assert response.status_code == 200
+    assert "id" in guest
+    assert "name" in guest
+    assert "slug" in guest
+    assert "appearances" in guest
+
+
+def test_guests_random_id():
+    """Test /v2.0/guests/random/id route."""
+    response = client.get(f"/v{API_VERSION}/guests/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_guests_random_slug():
+    """Test /v2.0/guests/random/slug route."""
+    response = client.get(f"/v{API_VERSION}/guests/random/slug")
+    _slug = response.json()
+
+    assert response.status_code == 200
+    assert "slug" in _slug
+    assert isinstance(_slug["slug"], str)

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -97,3 +97,48 @@ def test_hosts_details_slug(host_slug: str):
     assert "slug" in host
     assert host["slug"] == host_slug
     assert "appearances" in host
+
+
+def test_hosts_random():
+    """Test /v2.0/hosts/random route."""
+    response = client.get(f"/v{API_VERSION}/hosts/random")
+    host = response.json()
+
+    assert response.status_code == 200
+    assert "id" in host
+    assert "name" in host
+    assert "pronouns" in host
+    assert "slug" in host
+
+
+def test_hosts_random_details():
+    """Test /v2.0/hosts/random/details route."""
+    response = client.get(f"/v{API_VERSION}/hosts/random/details")
+    host = response.json()
+
+    assert response.status_code == 200
+    assert "id" in host
+    assert "name" in host
+    assert "pronouns" in host
+    assert "slug" in host
+    assert "appearances" in host
+
+
+def test_hosts_random_id():
+    """Test /v2.0/hosts/random/id route."""
+    response = client.get(f"/v{API_VERSION}/hosts/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_hosts_random_slug():
+    """Test /v2.0/hosts/random/slug route."""
+    response = client.get(f"/v{API_VERSION}/hosts/random/slug")
+    _slug = response.json()
+
+    assert response.status_code == 200
+    assert "slug" in _slug
+    assert isinstance(_slug["slug"], str)

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -7,6 +7,7 @@
 
 import pytest
 from fastapi.testclient import TestClient
+from numpy import isin
 
 from app.config import API_VERSION
 from app.main import app
@@ -129,3 +130,85 @@ def test_locations_recordings_slug(location_slug: str):
         assert "latitude" in location["coordinates"]
         assert "longitude" in location["coordinates"]
     assert "recordings" in location
+
+
+def test_locations_postal_abbreviations():
+    """Test /v2.0/locations/postal-abbreviations route."""
+    response = client.get(f"/v{API_VERSION}/locations/postal-abbreviations")
+    abbreviations = response.json()
+
+    assert response.status_code == 200
+    assert isinstance(abbreviations, list)
+    assert isinstance(abbreviations[0], str)
+
+
+def test_locations_postal_abbreviations_details_all():
+    """Test /v2.0/locations/postal-abbreviations/details route."""
+    response = client.get(f"/v{API_VERSION}/locations/postal-abbreviations/details")
+    abbreviations = response.json()
+
+    assert response.status_code == 200
+    assert "postal_abbreviations" in abbreviations
+    assert isinstance(abbreviations["postal_abbreviations"], list)
+    assert isinstance(abbreviations["postal_abbreviations"][0], dict)
+    assert "postal_abbreviation" in abbreviations["postal_abbreviations"][0]
+    assert "name" in abbreviations["postal_abbreviations"][0]
+    assert "country" in abbreviations["postal_abbreviations"][0]
+
+
+@pytest.mark.parametrize("abbreviation", ["OR", "DC"])
+def test_locations_postal_abbreviations_details(abbreviation: str):
+    """Test /v2.0/locations/postal-abbreviations/details route."""
+    response = client.get(
+        f"/v{API_VERSION}/locations/postal-abbreviations/details/{abbreviation}"
+    )
+    info = response.json()
+
+    assert response.status_code == 200
+    assert isinstance(info, dict)
+    assert "postal_abbreviation" in info
+    assert "name" in info
+    assert "country" in info
+
+
+def test_locations_random():
+    """Test /v2.0/locations/random route."""
+    response = client.get(f"/v{API_VERSION}/locations/random")
+    location = response.json()
+
+    assert response.status_code == 200
+    assert "id" in location
+    assert "venue" in location
+    assert "slug" in location
+
+
+def test_locations_random_details():
+    """Test /v2.0/locations/random/details route."""
+    response = client.get(f"/v{API_VERSION}/locations/random/details")
+    location = response.json()
+
+    assert response.status_code == 200
+    assert "id" in location
+    assert "venue" in location
+    assert "slug" in location
+    assert "recordings" in location
+
+
+def test_locations_random_id():
+    """Test /v2.0/locations/random/id route."""
+    response = client.get(f"/v{API_VERSION}/locations/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_locations_random_slug():
+    """Test /v2.0/locations/random/slug route."""
+    response = client.get(f"/v{API_VERSION}/locations/random/slug")
+    _slug = response.json()
+
+    assert response.status_code == 200
+    assert "slug" in _slug
+    assert isinstance(_slug["slug"], str)

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -165,3 +165,48 @@ def test_panelists_scores_grouped_ordered_pair_slug(panelist_slug: str):
 
     assert response.status_code == 200
     assert "scores" in scores
+
+
+def test_panelists_random():
+    """Test /v2.0/panelists/random route."""
+    response = client.get(f"/v{API_VERSION}/panelists/random")
+    panelist = response.json()
+
+    assert response.status_code == 200
+    assert "id" in panelist
+    assert "name" in panelist
+    assert "pronouns" in panelist
+    assert "slug" in panelist
+
+
+def test_panelists_random_details():
+    """Test /v2.0/panelists/random/details route."""
+    response = client.get(f"/v{API_VERSION}/panelists/random/details")
+    panelist = response.json()
+
+    assert response.status_code == 200
+    assert "id" in panelist
+    assert "name" in panelist
+    assert "pronouns" in panelist
+    assert "slug" in panelist
+    assert "appearances" in panelist
+
+
+def test_panelists_random_id():
+    """Test /v2.0/panelists/random/id route."""
+    response = client.get(f"/v{API_VERSION}/panelists/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_panelists_random_slug():
+    """Test /v2.0/panelists/random/slug route."""
+    response = client.get(f"/v{API_VERSION}/panelists/random/slug")
+    _slug = response.json()
+
+    assert response.status_code == 200
+    assert "slug" in _slug
+    assert isinstance(_slug["slug"], str)

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -99,3 +99,48 @@ def test_scorekeepers_details_slug(scorekeeper_slug: str):
     assert "slug" in scorekeeper
     assert scorekeeper["slug"] == scorekeeper_slug
     assert "appearances" in scorekeeper
+
+
+def test_scorekeepers_random():
+    """Test /v2.0/scorekeepers/random route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/random")
+    scorekeeper = response.json()
+
+    assert response.status_code == 200
+    assert "id" in scorekeeper
+    assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
+    assert "slug" in scorekeeper
+
+
+def test_scorekeepers_random_details():
+    """Test /v2.0/scorekeepers/random/details route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/random/details")
+    scorekeeper = response.json()
+
+    assert response.status_code == 200
+    assert "id" in scorekeeper
+    assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
+    assert "slug" in scorekeeper
+    assert "appearances" in scorekeeper
+
+
+def test_scorekeepers_random_id():
+    """Test /v2.0/scorekeepers/random/id route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_scorekeepers_random_slug():
+    """Test /v2.0/scorekeepers/random/slug route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/random/slug")
+    _slug = response.json()
+
+    assert response.status_code == 200
+    assert "slug" in _slug
+    assert isinstance(_slug["slug"], str)

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -406,3 +406,59 @@ def test_shows_repeats():
     assert isinstance(shows["shows"][0]["original_show_id"], int)
     assert "original_show_date" in shows["shows"][0]
     assert isinstance(shows["shows"][0]["original_show_date"], str)
+
+
+def test_shows_random():
+    """Test /v2.0/shows/random route."""
+    response = client.get(f"/v{API_VERSION}/shows/random")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert "date" in show
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+
+
+def test_shows_random_details():
+    """Test /v2.0/shows/random/details route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/details")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert "date" in show
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+    assert "location" in show
+    assert "description" in show
+    assert "host" in show
+    assert "scorekeeper" in show
+    assert "panelists" in show
+    assert "guests" in show
+
+
+def test_shows_random_id():
+    """Test /v2.0/shows/random/id route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/id")
+    _id = response.json()
+
+    assert response.status_code == 200
+    assert "id" in _id
+    assert isinstance(_id["id"], int)
+
+
+def test_shows_random_date():
+    """Test /v2.0/shows/random/date route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/date")
+    _date = response.json()
+
+    assert response.status_code == 200
+    assert "date" in _date
+    assert isinstance(_date["date"], str)


### PR DESCRIPTION
## Application Changes

- Add `/random`, `/random/details`, `/random/id`, and `/random/slug` endpoints to Guests, Hosts, Locations, Panelists and Scorekeepers to retrieve a random item, ID or slug string from the corresponding sections
- Add `/random`, `/random/details`, `/random/id` and `/random/date` endpoints to Shows to retrieve a random show, ID or ISO-formatted date string
- Add `/postal-abbreviations`, `/postal-abbreviations/details` and `/postal-abbreviations/details/{abbreviation}` endpoints to Locations to get a list of postal abbreviations, get details for all available postal abbreviations, and get details for a specific postal abbreviation
- Add `PostalAbbreviationDetails`, `PostalAbbreviations` and `PostalAbbreviationsDetails` models for the above endpoints

## Component Changes

- Upgrade wwdtm from 2.15.0 to 2.16.1

## Development Changes

- Added tests for all of the new endpoints