### PR TITLE
Endpoint naming consistency updates, fix decimal score setting passthrough, bump component versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changes
 
+## 2.17.0
+
+### Application Changes
+
+- Change `/random/details` to `/details/random` and `/recordings/random` for the appropriate endpoints to match the endpoint naming with the other endpoints
+- Passthrough the `use_decimal_scores` configuration settings value to the `include_decimal_scores` and `use_decimal_scores` corresponding method parameters
+
+### Component Changes
+
+- Upgrade pydantic from 2.8.2 to 2.10.6
+- Upgrade fastapi from 0.115.0 to 0.115.8
+- Upgrade uvicorn from 0.30.6 to 0.34.0
+- Upgrade httpx from 0.27.2 to 0.28.1
+- Upgrade wwdtm from 2.16.1 to 2.17.1
+
+### Development Changes
+
+- Upgrade pytest from 8.3.3
+- Upgrade pytest-cov from 5.0.0 to 6.0.0
+- Add testing for the `format_umami_analytics` function in `/app/umami_analytics.py`
+
 ## 2.16.0
 
 ### Application Changes

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -203,6 +203,40 @@ async def get_guest_details_by_id(
 
 
 @router.get(
+    "/details/random",
+    summary="Retrieve Information and Appearances for a Random Not My Job Guest",
+    response_model=ModelsGuestDetails,
+    tags=["Guests"],
+)
+@router.head("/details/random", include_in_schema=False)
+async def get_random_guest_details():
+    """Retrieve a Random Not My Job Guest.
+
+    Returned data: Guest ID, name, slug string, appearances and scores.
+
+    Appearances are sorted by date.
+    """
+    try:
+        guest = Guest(database_connection=_database_connection)
+        guest_details = guest.retrieve_random_details()
+        if guest_details:
+            return guest_details
+
+        raise HTTPException(status_code=404, detail="Random Guest not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Guest not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve guest information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve guest information",
+        ) from None
+
+
+@router.get(
     "/details/slug/{guest_slug}",
     summary="Retrieve Information and Appearances by Guest Slug String",
     response_model=ModelsGuestDetails,
@@ -259,40 +293,6 @@ async def get_random_guest():
         guest_info = guest.retrieve_random()
         if guest_info:
             return guest_info
-
-        raise HTTPException(status_code=404, detail="Random Guest not found")
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Random Guest not found") from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Information and Appearances for a Random Not My Job Guest",
-    response_model=ModelsGuestDetails,
-    tags=["Guests"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_guest_details():
-    """Retrieve a Random Not My Job Guest.
-
-    Returned data: Guest ID, name, slug string, appearances and scores.
-
-    Appearances are sorted by date.
-    """
-    try:
-        guest = Guest(database_connection=_database_connection)
-        guest_details = guest.retrieve_random_details()
-        if guest_details:
-            return guest_details
 
         raise HTTPException(status_code=404, detail="Random Guest not found")
     except ValueError:

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -203,6 +203,40 @@ async def get_host_details_by_id(
 
 
 @router.get(
+    "/details/random",
+    summary="Retrieve Information and Appearances for a Random Host",
+    response_model=ModelsHostDetails,
+    tags=["Hosts"],
+)
+@router.head("/details/random", include_in_schema=False)
+async def get_random_host_details():
+    """Retrieve a Random Host.
+
+    Returned data: Host ID, name, slug string, gender, and appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        host = Host(database_connection=_database_connection)
+        host_details = host.retrieve_random_details()
+        if host_details:
+            return host_details
+
+        raise HTTPException(status_code=404, detail="Random Host not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random Host not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve host information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve host information",
+        ) from None
+
+
+@router.get(
     "/details/slug/{host_slug}",
     summary="Retrieve Information and Appearances by Host by Slug String",
     response_model=ModelsHostDetails,
@@ -259,40 +293,6 @@ async def get_random_host():
         host_info = host.retrieve_random()
         if host_info:
             return host_info
-
-        raise HTTPException(status_code=404, detail="Random Host not found")
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Random Host not found") from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Information and Appearances for a Random Host",
-    response_model=ModelsHostDetails,
-    tags=["Hosts"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_host_details():
-    """Retrieve a Random Host.
-
-    Returned data: Host ID, name, slug string, gender, and appearances.
-
-    Appearances are sorted by date.
-    """
-    try:
-        host = Host(database_connection=_database_connection)
-        host_details = host.retrieve_random_details()
-        if host_details:
-            return host_details
 
         raise HTTPException(status_code=404, detail="Random Host not found")
     except ValueError:

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -222,6 +222,42 @@ async def get_location_recordings_by_id(
 
 
 @router.get(
+    "/recordings/random",
+    summary="Retrieve Information and Recordings for a Random Location",
+    response_model=ModelsLocationDetails,
+    tags=["Locations"],
+)
+@router.head("/recordings/random", include_in_schema=False)
+async def get_random_location_details():
+    """Retrieve a Random Location.
+
+    Returned data: Location ID, venue, city, state, slug string, and recordings.
+
+    Appearances are sorted by date.
+    """
+    try:
+        location = Location(database_connection=_database_connection)
+        location_details = location.retrieve_random_details()
+        if location_details:
+            return location_details
+
+        raise HTTPException(status_code=404, detail="Random Location not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Location not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve location information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve location information",
+        ) from None
+
+
+@router.get(
     "/recordings/slug/{location_slug}",
     summary="Retrieve Information and Recordings by Location Slug String",
     response_model=ModelsLocationDetails,
@@ -392,42 +428,6 @@ async def get_random_location():
         location_info = location.retrieve_random()
         if location_info:
             return location_info
-
-        raise HTTPException(status_code=404, detail="Random Location not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Location not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Information and Appearances for a Random Location",
-    response_model=ModelsLocationDetails,
-    tags=["Locations"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_location_details():
-    """Retrieve a Random Location.
-
-    Returned data: Location ID, venue, city, state, slug string, and recordings.
-
-    Appearances are sorted by date.
-    """
-    try:
-        location = Location(database_connection=_database_connection)
-        location_details = location.retrieve_random_details()
-        if location_details:
-            return location_details
 
         raise HTTPException(status_code=404, detail="Random Location not found")
     except ValueError:

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -226,6 +226,45 @@ async def get_panelist_details_by_id(
 
 
 @router.get(
+    "/details/random",
+    summary="Retrieve Information and Appearances for a Random Panelist",
+    response_model=ModelsPanelistDetails,
+    tags=["Panelists"],
+)
+@router.head("/details/random", include_in_schema=False)
+async def get_random_panelist_details():
+    """Retrieve a Random Panelist.
+
+    Returned data: Panelist ID, name, slug string, gender, statistics
+    and appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        panelist = Panelist(database_connection=_database_connection)
+        panelist_details = panelist.retrieve_random_details(
+            use_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
+        if panelist_details:
+            return panelist_details
+
+        raise HTTPException(status_code=404, detail="Random Panelist not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Panelist not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve panelist information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve panelist information",
+        ) from None
+
+
+@router.get(
     "/details/slug/{panelist_slug}",
     summary="Retrieve Information, Statistics and Appearances by Panelist by Slug String",
     response_model=ModelsPanelistDetails,
@@ -589,43 +628,6 @@ async def get_random_panelist():
         panelist_info = panelist.retrieve_random()
         if panelist_info:
             return panelist_info
-
-        raise HTTPException(status_code=404, detail="Random Panelist not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Panelist not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Information and Appearances for a Random Panelist",
-    response_model=ModelsPanelistDetails,
-    tags=["Panelists"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_panelist_details():
-    """Retrieve a Random Panelist.
-
-    Returned data: Panelist ID, name, slug string, gender, statistics
-    and appearances.
-
-    Appearances are sorted by date.
-    """
-    try:
-        panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_random_details()
-        if panelist_details:
-            return panelist_details
 
         raise HTTPException(status_code=404, detail="Random Panelist not found")
     except ValueError:

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -218,6 +218,43 @@ async def get_scorekeeper_details_by_id(
 
 
 @router.get(
+    "/details/random",
+    summary="Retrieve Information and Appearances for a Random Scorekeeper",
+    response_model=ModelsScorekeeperDetails,
+    tags=["Scorekeepers"],
+)
+@router.head("/details/random", include_in_schema=False)
+async def get_random_scorekeeper_details():
+    """Retrieve a Random Scorekeeper.
+
+    Returned data: Scorekeeper ID, name, slug string, gender, and
+    appearances.
+
+    Appearances are sorted by date.
+    """
+    try:
+        scorekeeper = Scorekeeper(database_connection=_database_connection)
+        scorekeeper_details = scorekeeper.retrieve_random_details()
+        if scorekeeper_details:
+            return scorekeeper_details
+
+        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random Scorekeeper not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500, detail="Unable to retrieve scorekeeper information"
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve scorekeeper information",
+        ) from None
+
+
+@router.get(
     "/details/slug/{scorekeeper_slug}",
     summary="Retrieve Information and Appearances by Scorekeeper by Slug String",
     response_model=ModelsScorekeeperDetails,
@@ -281,43 +318,6 @@ async def get_random_scorekeeper():
         scorekeeper_info = scorekeeper.retrieve_random()
         if scorekeeper_info:
             return scorekeeper_info
-
-        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Information and Appearances for a Random Scorekeeper",
-    response_model=ModelsScorekeeperDetails,
-    tags=["Scorekeepers"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_scorekeeper_details():
-    """Retrieve a Random Scorekeeper.
-
-    Returned data: Scorekeeper ID, name, slug string, gender, and
-    appearances.
-
-    Appearances are sorted by date.
-    """
-    try:
-        scorekeeper = Scorekeeper(database_connection=_database_connection)
-        scorekeeper_details = scorekeeper.retrieve_random_details()
-        if scorekeeper_details:
-            return scorekeeper_details
 
         raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
     except ValueError:

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -710,6 +710,87 @@ async def get_show_details_by_date(
 
 
 @router.get(
+    "/details/random",
+    summary="Retrieve Detailed Information for a Random Show",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/random", include_in_schema=False)
+async def get_random_show_details():
+    """Retrieve Details for a Random Show.
+
+    Return data: Show ID, date, Best Of flag, Repeat flag or date,
+    NPR.org show URL, location, description, notes, host, scorekeeper,
+    panelists, Bluff information and Not My Job guests
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_random_details(
+            include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
+        if show_details:
+            return show_details
+
+        raise HTTPException(status_code=404, detail="Random show not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random show not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
+    "/details/random/year/{year}",
+    summary="Retrieve Detailed Information for a Random Show for a Given Year",
+    response_model=ModelsShowDetails,
+    tags=["Shows"],
+)
+@router.head("/details/random/year/{year}", include_in_schema=False)
+async def get_random_show_by_year_details(
+    year: Annotated[
+        int, Path(title="The year to get a random show for", ge=1998, le=9999)
+    ],
+):
+    """Retrieve Details for a Random Show of a given year.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and NPR.org
+    show URL
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_details = show.retrieve_random_details_by_year(
+            year=year, include_decimal_scores=_config["settings"]["use_decimal_scores"]
+        )
+        if show_details:
+            return show_details
+
+        raise HTTPException(
+            status_code=404, detail=f"Random show for {year:04d} not found"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail=f"Random show for {year:04d} not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
     "/details/recent",
     summary="Retrieve Detailed Information for Recent Shows",
     response_model=ModelsShowsDetails,
@@ -811,6 +892,152 @@ async def get_details_repeats():
 
 
 @router.get(
+    "/random",
+    summary="Retrieve Information for a Random Show",
+    response_model=ModelsShow,
+    tags=["Shows"],
+)
+@router.head("/random", include_in_schema=False)
+async def get_random_show():
+    """Retrieve Information for a Random Show.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and NPR.org
+    show URL
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_random()
+        if show_info:
+            return show_info
+
+        raise HTTPException(status_code=404, detail="Random show not found")
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Random show not found") from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
+    "/random/id",
+    summary="Retrieve a Random Show ID",
+    response_model=ModelsShowID,
+    tags=["Shows"],
+)
+@router.head("/random/id", include_in_schema=False)
+async def get_random_show_id():
+    """Retrieve a Random Show ID.
+
+    Returned data: Show ID.
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        _id = show.retrieve_random_id()
+        if _id:
+            return {"id": _id}
+
+        raise HTTPException(status_code=404, detail="Random show ID not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random show ID not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve a random show ID",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random show ID",
+        ) from None
+
+
+@router.get(
+    "/random/date",
+    summary="Retrieve a Random Show Date",
+    response_model=ModelsShowDate,
+    tags=["Shows"],
+)
+@router.head("/random/date", include_in_schema=False)
+async def get_random_show_date():
+    """Retrieve a Random Show Date.
+
+    Returned data: Show Date.
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        _date = show.retrieve_random_date()
+        if _date:
+            return {"date": _date}
+
+        raise HTTPException(status_code=404, detail="Random show date not found")
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail="Random show date not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve a random show date",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while trying to retrieve a random show date",
+        ) from None
+
+
+@router.get(
+    "/random/year/{year}",
+    summary="Retrieve Information for a Random Show for a Given Year",
+    response_model=ModelsShow,
+    tags=["Shows"],
+)
+@router.head("/random/year/{year}", include_in_schema=False)
+async def get_random_show_by_year(
+    year: Annotated[
+        int, Path(title="The year to get a random show for", ge=1998, le=9999)
+    ],
+):
+    """Retrieve Information for a Random Show of a given year.
+
+    Returned data: Show ID, date, Best Of flag, Repeat flag and NPR.org
+    show URL
+    """
+    try:
+        show = Show(database_connection=_database_connection)
+        show_info = show.retrieve_random_by_year(year=year)
+        if show_info:
+            return show_info
+
+        raise HTTPException(
+            status_code=404, detail=f"Random show for {year:04d} not found"
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=404, detail=f"Random show for {year:04d} not found"
+        ) from None
+    except ProgrammingError:
+        raise HTTPException(
+            status_code=500,
+            detail="Unable to retrieve show information from the database",
+        ) from None
+    except DatabaseError:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error occurred while retrieving show information from the database",
+        ) from None
+
+
+@router.get(
     "/recent",
     summary="Retrieve Information for Recent Shows",
     response_model=ModelsShows,
@@ -904,143 +1131,4 @@ async def get_repeat_best_ofs():
             status_code=500,
             detail="Database error occurred while retrieving Repeat Best Of shows "
             "from the database",
-        ) from None
-
-
-@router.get(
-    "/random",
-    summary="Retrieve Information for a Random Show",
-    response_model=ModelsShow,
-    tags=["Shows"],
-)
-@router.head("/random", include_in_schema=False)
-async def get_random_show():
-    """Retrieve Information for a Random Show.
-
-    Returned data: Show ID, date, Best Of flag, Repeat flag and NPR.org
-    show URL
-    """
-    try:
-        show = Show(database_connection=_database_connection)
-        show_info = show.retrieve_random()
-        if show_info:
-            return show_info
-
-        raise HTTPException(status_code=404, detail="Random Show not found")
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Random Show not found") from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500,
-            detail="Unable to retrieve show information from the database",
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while retrieving show information from the database",
-        ) from None
-
-
-@router.get(
-    "/random/details",
-    summary="Retrieve Detailed Information for a Random Show",
-    response_model=ModelsShowDetails,
-    tags=["Shows"],
-)
-@router.head("/random/details", include_in_schema=False)
-async def get_random_show_details():
-    """Retrieve Details for a Random Show.
-
-    Return data: Show ID, date, Best Of flag, Repeat flag or date,
-    NPR.org show URL, location, description, notes, host, scorekeeper,
-    panelists, Bluff information and Not My Job guests
-    """
-    try:
-        show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_random_details()
-        if show_details:
-            return show_details
-
-        raise HTTPException(status_code=404, detail="Random Show not found")
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Random Show not found") from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500,
-            detail="Unable to retrieve show information from the database",
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while retrieving show information from the database",
-        ) from None
-
-
-@router.get(
-    "/random/id",
-    summary="Retrieve a Random Show ID",
-    response_model=ModelsShowID,
-    tags=["Shows"],
-)
-@router.head("/random/id", include_in_schema=False)
-async def get_random_show_id():
-    """Retrieve a Random Show ID.
-
-    Returned data: Show ID.
-    """
-    try:
-        show = Show(database_connection=_database_connection)
-        _id = show.retrieve_random_id()
-        if _id:
-            return {"id": _id}
-
-        raise HTTPException(status_code=404, detail="Random Show ID not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Show ID not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500,
-            detail="Unable to retrieve a random show ID",
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve a random show ID",
-        ) from None
-
-
-@router.get(
-    "/random/date",
-    summary="Retrieve a Random Show Date",
-    response_model=ModelsShowDate,
-    tags=["Shows"],
-)
-@router.head("/random/date", include_in_schema=False)
-async def get_random_show_date():
-    """Retrieve a Random Show Date.
-
-    Returned data: Show Date.
-    """
-    try:
-        show = Show(database_connection=_database_connection)
-        _date = show.retrieve_random_date()
-        if _date:
-            return {"date": _date}
-
-        raise HTTPException(status_code=404, detail="Random Show Date not found")
-    except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Show Date not found"
-        ) from None
-    except ProgrammingError:
-        raise HTTPException(
-            status_code=500,
-            detail="Unable to retrieve a random show date",
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
-            status_code=500,
-            detail="Database error occurred while trying to retrieve a random show date",
         ) from None

--- a/app/utility.py
+++ b/app/utility.py
@@ -11,7 +11,7 @@ def format_umami_analytics(umami_analytics: dict = None) -> str:
     if not umami_analytics:
         return None
 
-    _enabled = bool(umami_analytics.get("_enabled", False))
+    _enabled = bool(umami_analytics.get("enabled", False))
 
     if not _enabled:
         return None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 ruff==0.9.3
-pytest==8.3.3
-pytest-cov==5.0.0
+pytest==8.3.4
+pytest-cov==6.0.0
 
-pydantic==2.8.2
-fastapi==0.115.0
-uvicorn[standard]==0.30.6
+pydantic==2.10.6
+fastapi==0.115.8
+uvicorn[standard]==0.34.0
 gunicorn==23.0.0
-httpx==0.27.2
+httpx==0.28.1
 aiofiles==24.1.0
 jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.16.1
+wwdtm==2.17.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pydantic==2.8.2
-fastapi==0.115.0
-uvicorn[standard]==0.30.6
+pydantic==2.10.6
+fastapi==0.115.8
+uvicorn[standard]==0.34.0
 gunicorn==23.0.0
-httpx==0.27.2
+httpx==0.28.1
 aiofiles==24.1.0
 jinja2==3.1.5
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.16.1
+wwdtm==2.17.2

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -105,8 +105,8 @@ def test_guests_random():
 
 
 def test_guests_random_details():
-    """Test /v2.0/guests/random/details route."""
-    response = client.get(f"/v{API_VERSION}/guests/random/details")
+    """Test /v2.0/guests/details/random route."""
+    response = client.get(f"/v{API_VERSION}/guests/details/random")
     guest = response.json()
 
     assert response.status_code == 200

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -112,8 +112,8 @@ def test_hosts_random():
 
 
 def test_hosts_random_details():
-    """Test /v2.0/hosts/random/details route."""
-    response = client.get(f"/v{API_VERSION}/hosts/random/details")
+    """Test /v2.0/hosts/details/random route."""
+    response = client.get(f"/v{API_VERSION}/hosts/details/random")
     host = response.json()
 
     assert response.status_code == 200

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -183,8 +183,8 @@ def test_locations_random():
 
 
 def test_locations_random_details():
-    """Test /v2.0/locations/random/details route."""
-    response = client.get(f"/v{API_VERSION}/locations/random/details")
+    """Test /v2.0/locations/recordings/random route."""
+    response = client.get(f"/v{API_VERSION}/locations/recordings/random")
     location = response.json()
 
     assert response.status_code == 200

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -180,8 +180,8 @@ def test_panelists_random():
 
 
 def test_panelists_random_details():
-    """Test /v2.0/panelists/random/details route."""
-    response = client.get(f"/v{API_VERSION}/panelists/random/details")
+    """Test /v2.0/panelists/details/random route."""
+    response = client.get(f"/v{API_VERSION}/panelists/details/random")
     panelist = response.json()
 
     assert response.status_code == 200

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -114,8 +114,8 @@ def test_scorekeepers_random():
 
 
 def test_scorekeepers_random_details():
-    """Test /v2.0/scorekeepers/random/details route."""
-    response = client.get(f"/v{API_VERSION}/scorekeepers/random/details")
+    """Test /v2.0/scorekeepers/details/random route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/details/random")
     scorekeeper = response.json()
 
     assert response.status_code == 200

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -424,13 +424,53 @@ def test_shows_random():
 
 
 def test_shows_random_details():
-    """Test /v2.0/shows/random/details route."""
-    response = client.get(f"/v{API_VERSION}/shows/random/details")
+    """Test /v2.0/shows/details/random route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/random")
     show = response.json()
 
     assert response.status_code == 200
     assert "id" in show
     assert "date" in show
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+    assert "location" in show
+    assert "description" in show
+    assert "host" in show
+    assert "scorekeeper" in show
+    assert "panelists" in show
+    assert "guests" in show
+
+
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_shows_random_show_by_year(year: int):
+    """Test /v2.0/shows/random/year/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/year/{year}")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert "date" in show
+    assert str(year) in show["date"]
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+
+
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_shows_random_show_by_year_details(year: int):
+    """Test /v2.0/shows/details/random/year/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/random/year/{year}")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert "date" in show
+    assert str(year) in show["date"]
     assert "best_of" in show
     assert "repeat_show" in show
     assert "show_url" in show

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2018-2025 Linh Pham
+# api.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Utility Methods."""
+
+from app.utility import format_umami_analytics
+
+_umami_disabled_config = {
+    "enabled": False,
+    "url": "http://test/test.js",
+    "data_website_id": "test-value",
+    "data_domains": "test.url",
+    "data_auto_track": True,
+}
+
+_umami_enabled_config = {
+    "enabled": True,
+    "url": "http://test/test.js",
+    "data_website_id": "test-value",
+    "data_domains": "test.url",
+    "data_auto_track": True,
+}
+
+_umami_invalid_config = {
+    "enabled": True,
+    "url": "",
+    "data_website_id": "",
+}
+
+
+def test_format_umami_analytics_empty():
+    """Test utility.format_umami_analytics with no valid configuration."""
+    _analytics = format_umami_analytics(umami_analytics={})
+    assert not _analytics, "Returned Umami Analytics is not None"
+
+    _analytics = format_umami_analytics(umami_analytics=None)
+    assert not _analytics, "Returned Umami Analytics is not None"
+
+
+def test_format_umami_analytics_disabled():
+    """Test utility.format_umami_analytics with enabled flag set to false."""
+    _analytics = format_umami_analytics(umami_analytics=_umami_disabled_config)
+    assert not _analytics, "Returned Umami Analytics is not None"
+
+
+def test_format_umami_analytics_enabled():
+    """Test utility.format_umami_analytics with enabled flag set to true."""
+    _analytics = format_umami_analytics(umami_analytics=_umami_enabled_config)
+    assert _analytics, "Returned Umami Analytics string is not valid"
+    assert _umami_enabled_config["url"] in _analytics, (
+        "Returned Umami Analytics string missing or has incorrect 'url' value"
+    )
+    assert _umami_enabled_config["data_website_id"] in _analytics, (
+        "Returned Umami Analytics string missing or has incorrect 'website_id' value"
+    )
+
+    if _umami_enabled_config["data_auto_track"]:
+        assert str(_umami_enabled_config["data_auto_track"]).lower() in _analytics, (
+            "Returned Umami Analytics string missing or has missing 'data_auto_track' value"
+        )
+
+    if _umami_enabled_config["data_domains"]:
+        assert _umami_enabled_config["data_domains"] in _analytics, (
+            "Returned Umami Analytics string missing or has missing 'data_domains' value"
+        )
+
+
+def test_format_umami_analytics_invalid():
+    """Test utility.format_umami_analytics with an invalid configuration."""
+    _analytics = format_umami_analytics(umami_analytics=_umami_invalid_config)
+    assert not _analytics, "Returned Umami Analytics is not None"


### PR DESCRIPTION
## Application Changes

- Change `/random/details` to `/details/random` and `/recordings/random` for the appropriate endpoints to match the endpoint naming with the other endpoints
- Passthrough the `use_decimal_scores` configuration settings value to the `include_decimal_scores` and `use_decimal_scores` corresponding method parameters

## Component Changes

- Upgrade pydantic from 2.8.2 to 2.10.6
- Upgrade fastapi from 0.115.0 to 0.115.8
- Upgrade uvicorn from 0.30.6 to 0.34.0
- Upgrade httpx from 0.27.2 to 0.28.1
- Upgrade wwdtm from 2.16.1 to 2.17.1

## Development Changes

- Upgrade pytest from 8.3.3
- Upgrade pytest-cov from 5.0.0 to 6.0.0
- Add testing for the `format_umami_analytics` function in `/app/umami_analytics.py`