### PR TITLE
Add new endpoints and tests, cleanup, MessageDetails response model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,33 @@
 # Changes
 
+## 2.18.0
+
+### Application Changes
+
+- Replace `raise HTTPException` with using `return JSONResponse` and use a new `MessageDetails` response model to validate the response. The returned message uses the same format, but this change adds a specific response model to the OpenAPI specification.
+- Updates to the Shows API endpoints
+  - Add optional `inclusive` boolean query paramter to `/best-ofs` and `/details/best-ofs` that will determine whether to include Repeat Best Of shows along with non-repeat Best Of shows (default: `true`)
+  - Add optional `inclusive` boolean query paramter to `/repeats` and `/details/repeats` that will determine whether to include Repeat Best Of shows along with non-Best Of repeat shows (default: `true`)
+  - Fix response model issue with `/details/best-ofs` and `/details/repeats`
+  - Add missing `include_decimal_scores` named parameter and values to show retrieval method calls for `/details/best-ofs`, `/details/repeat-best-ofs` and `/details/repeats` endpoints
+- Added the following Show endpoints:
+  - `/date/{year}/best-ofs`
+  - `/date/{year}/repeat-best-ofs`
+  - `/date/{year}/repeats`
+  - `/details/date/{year}/best-ofs`
+  - `/details/date/{year}/repeat-best-ofs`
+  - `/details/date/{year}/repeats`
+- Renamed endpoint function names in order to have a more consistent naming convention
+
+### Development Changes
+
+- Add missing tests for `/details/best-ofs`, `/details/repeat-best-ofs` and `/details/repeats`
+- Rename test function names to use a `test_` prefix and the name of the API endpoint function name
+- Add tests cases to check if endpoints are returning `404` when there are no corresponding values
+
 ## 2.17.2
 
-## Component Changes
+### Component Changes
 
 - Upgrade jinja2 from 3.1.5 to 3.1.6
 

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.17.2"
+APP_VERSION = "2.18.0"
 
 
 def load_config(

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from .utility import format_umami_analytics
 
 app = FastAPI(
     title=app_metadata["title"],
-    description=app_metadata["description"],
+    description=app_metadata["description"].strip(),
     openapi_tags=tags_metadata,
     version=APP_VERSION,
     contact=app_metadata["contact_info"],
@@ -102,7 +102,7 @@ async def robots_txt():
     if robots_txt_dist_path.exists():
         return FileResponse(path="static/robots.txt.dist", media_type="text/plain")
 
-    raise HTTPException(status_code=404)
+    return HTTPException(status_code=404)
 
 
 @app.get("/docs", include_in_schema=False, response_class=RedirectResponse)

--- a/app/models/messages.py
+++ b/app/models/messages.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2018-2025 Linh Pham
+# api.wwdt.me is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Response Message Models."""
+
+from pydantic import BaseModel, Field
+
+
+class MessageDetails(BaseModel):
+    """Response Message Details."""
+
+    detail: str = Field(title="Message details")

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -8,7 +8,8 @@
 from typing import Annotated
 
 import mysql.connector
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
+from fastapi.responses import JSONResponse
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.guest import Guest
 
@@ -19,6 +20,7 @@ from app.models.guests import GuestID as ModelsGuestID
 from app.models.guests import Guests as ModelsGuests
 from app.models.guests import GuestsDetails as ModelsGuestsDetails
 from app.models.guests import GuestSlug as ModelsGuestSlug
+from app.models.messages import MessageDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/guests")
 _config = load_config()
@@ -30,6 +32,7 @@ _database_connection = mysql.connector.connect(**_database_config)
     "",
     summary="Retrieve Information for All Not My Job Guests",
     response_model=ModelsGuests,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("", include_in_schema=False)
@@ -46,22 +49,26 @@ async def get_guests():
         if guests:
             return {"guests": guests}
 
-        raise HTTPException(status_code=404, detail="No guests found")
+        return JSONResponse(status_code=404, content={"detail": "No guests found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guests from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving guests from the database",
-        ) from None
+            content={"detail": "Unable to retrieve guests from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving guests from the database"
+            },
+        )
 
 
 @router.get(
     "/id/{guest_id}",
     summary="Retrieve Information by Not My Job Guest ID",
     response_model=ModelsGuest,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/id/{guest_id}", include_in_schema=False)
@@ -78,26 +85,31 @@ async def get_guest_by_id(
         if guest_info:
             return guest_info
 
-        raise HTTPException(status_code=404, detail=f"Guest ID {guest_id} not found")
+        return JSONResponse(
+            status_code=404, content={"detail": f"Guest ID {guest_id} not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Guest ID {guest_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Guest ID {guest_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/slug/{guest_slug}",
     summary="Retrieve Information by Guest Slug String",
     response_model=ModelsGuest,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/slug/{guest_slug}", include_in_schema=False)
@@ -114,28 +126,33 @@ async def get_guest_by_slug(
         if guest_info:
             return guest_info
 
-        raise HTTPException(
-            status_code=404, detail=f"Guest slug string {guest_slug} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Guest slug string {guest_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Guest slug string {guest_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Guest slug string {guest_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/details",
     summary="Retrieve Information and Appearances for All Not My Job Guests",
     response_model=ModelsGuestsDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/details", include_in_schema=False)
@@ -152,22 +169,26 @@ async def get_guests_details():
         if guests:
             return {"guests": guests}
 
-        raise HTTPException(status_code=404, detail="No guests found")
+        return JSONResponse(status_code=404, content={"detail": "No guests found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guests from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving guests from the database",
-        ) from None
+            content={"detail": "Unable to retrieve guests from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving guests from the database"
+            },
+        )
 
 
 @router.get(
     "/details/id/{guest_id}",
     summary="Retrieve Information and Appearances by Not My Job Guest ID",
     response_model=ModelsGuestDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/details/id/{guest_id}", include_in_schema=False)
@@ -186,26 +207,31 @@ async def get_guest_details_by_id(
         if guest_details:
             return guest_details
 
-        raise HTTPException(status_code=404, detail=f"Guest ID {guest_id} not found")
+        return JSONResponse(
+            status_code=404, content={"detail": f"Guest ID {guest_id} not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Guest ID {guest_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Guest ID {guest_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/details/random",
     summary="Retrieve Information and Appearances for a Random Not My Job Guest",
     response_model=ModelsGuestDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/details/random", include_in_schema=False)
@@ -222,24 +248,31 @@ async def get_random_guest_details():
         if guest_details:
             return guest_details
 
-        raise HTTPException(status_code=404, detail="Random Guest not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest not found"}
+        )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Random Guest not found") from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/details/slug/{guest_slug}",
     summary="Retrieve Information and Appearances by Guest Slug String",
     response_model=ModelsGuestDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/details/slug/{guest_slug}", include_in_schema=False)
@@ -258,28 +291,33 @@ async def get_guest_details_by_slug(
         if guest_details:
             return guest_details
 
-        raise HTTPException(
-            status_code=404, detail=f"Guest slug string {guest_slug} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Guest slug string {guest_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Guest slug string {guest_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Guest slug string {guest_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/random",
     summary="Retrieve Information for a Random Not My Job Guest",
     response_model=ModelsGuest,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/random", include_in_schema=False)
@@ -294,24 +332,31 @@ async def get_random_guest():
         if guest_info:
             return guest_info
 
-        raise HTTPException(status_code=404, detail="Random Guest not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest not found"}
+        )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Random Guest not found") from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve guest information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve guest information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve guest information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve guest information"
+            },
+        )
 
 
 @router.get(
     "/random/id",
     summary="Retrieve a Random Not My Job Guest ID",
     response_model=ModelsGuestID,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/random/id", include_in_schema=False)
@@ -326,26 +371,31 @@ async def get_random_guest_id():
         if guest_id:
             return {"id": guest_id}
 
-        raise HTTPException(status_code=404, detail="Random Guest ID not returned")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest ID not returned"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Guest ID not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest ID not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random guest ID"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve a random guest ID"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random guest ID",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve a random guest ID"
+            },
+        )
 
 
 @router.get(
     "/random/slug",
     summary="Retrieve a Random Not My Job Guest Slug String",
     response_model=ModelsGuestSlug,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Guests"],
 )
 @router.head("/random/slug", include_in_schema=False)
@@ -360,19 +410,22 @@ async def get_random_guest_slug():
         if guest_slug:
             return {"slug": guest_slug}
 
-        raise HTTPException(
-            status_code=404, detail="Random Guest slug string not returned"
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest slug string not returned"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Guest slug string not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Guest slug string not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random guest slug string"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random guest slug string",
-        ) from None
+            content={"detail": "Unable to retrieve a random guest slug string"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random guest slug string"
+            },
+        )

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -8,7 +8,8 @@
 from typing import Annotated
 
 import mysql.connector
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
+from fastapi.responses import JSONResponse
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.host import Host
 
@@ -19,6 +20,7 @@ from app.models.hosts import HostID as ModelsHostID
 from app.models.hosts import Hosts as ModelsHosts
 from app.models.hosts import HostsDetails as ModelsHostsDetails
 from app.models.hosts import HostSlug as ModelsHostSlug
+from app.models.messages import MessageDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/hosts")
 _config = load_config()
@@ -30,6 +32,7 @@ _database_connection = mysql.connector.connect(**_database_config)
     "",
     summary="Retrieve Information for All Hosts",
     response_model=ModelsHosts,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("", include_in_schema=False)
@@ -46,22 +49,26 @@ async def get_hosts():
         if hosts:
             return {"hosts": hosts}
 
-        raise HTTPException(status_code=404, detail="No hosts found")
+        return JSONResponse(status_code=404, content={"detail": "No hosts found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve hosts from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving hosts from the database",
-        ) from None
+            content={"detail": "Unable to retrieve hosts from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving hosts from the database"
+            },
+        )
 
 
 @router.get(
     "/id/{host_id}",
     summary="Retrieve Information by Host ID",
     response_model=ModelsHost,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/id/{host_id}", include_in_schema=False)
@@ -78,26 +85,31 @@ async def get_host_by_id(
         if host_info:
             return host_info
 
-        raise HTTPException(status_code=404, detail=f"Host ID {host_id} not found")
+        return JSONResponse(
+            status_code=404, content={"detail": f"Host ID {host_id} not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Host ID {host_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Host ID {host_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/slug/{host_slug}",
     summary="Retrieve Information by Host Slug String",
     response_model=ModelsHost,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/slug/{host_slug}", include_in_schema=False)
@@ -114,28 +126,33 @@ async def get_host_by_slug(
         if host_info:
             return host_info
 
-        raise HTTPException(
-            status_code=404, detail=f"Host slug string {host_slug} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Host slug string {host_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Host slug string {host_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Host slug string {host_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/details",
     summary="Retrieve Information and Appearances for All Hosts",
     response_model=ModelsHostsDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/details", include_in_schema=False)
@@ -152,22 +169,26 @@ async def get_hosts_details():
         if hosts:
             return {"hosts": hosts}
 
-        raise HTTPException(status_code=404, detail="No hosts found")
+        return JSONResponse(status_code=404, content={"detail": "No hosts found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve hosts from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving hosts from the database",
-        ) from None
+            content={"detail": "Unable to retrieve hosts from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving hosts from the database"
+            },
+        )
 
 
 @router.get(
     "/details/id/{host_id}",
     summary="Retrieve Information and Appearances by Host ID",
     response_model=ModelsHostDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/details/id/{host_id}", include_in_schema=False)
@@ -186,26 +207,31 @@ async def get_host_details_by_id(
         if host_details:
             return host_details
 
-        raise HTTPException(status_code=404, detail=f"Host ID {host_id} not found")
+        return JSONResponse(
+            status_code=404, content={"detail": f"Host ID {host_id} not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Host ID {host_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Host ID {host_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/details/random",
     summary="Retrieve Information and Appearances for a Random Host",
     response_model=ModelsHostDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/details/random", include_in_schema=False)
@@ -222,24 +248,31 @@ async def get_random_host_details():
         if host_details:
             return host_details
 
-        raise HTTPException(status_code=404, detail="Random Host not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host not found"}
+        )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Random Host not found") from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/details/slug/{host_slug}",
     summary="Retrieve Information and Appearances by Host by Slug String",
     response_model=ModelsHostDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/details/slug/{host_slug}", include_in_schema=False)
@@ -258,28 +291,33 @@ async def get_host_details_by_slug(
         if host_details:
             return host_details
 
-        raise HTTPException(
-            status_code=404, detail=f"Host slug string {host_slug} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Host slug string {host_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Host slug string {host_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Host slug string {host_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/random",
     summary="Retrieve Information for a Random Host",
     response_model=ModelsHost,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/random", include_in_schema=False)
@@ -294,24 +332,31 @@ async def get_random_host():
         if host_info:
             return host_info
 
-        raise HTTPException(status_code=404, detail="Random Host not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host not found"}
+        )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Random Host not found") from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve host information"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve host information"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve host information",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve host information"
+            },
+        )
 
 
 @router.get(
     "/random/id",
     summary="Retrieve a Random Host ID",
     response_model=ModelsHostID,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/random/id", include_in_schema=False)
@@ -326,26 +371,31 @@ async def get_random_host_id():
         if host_id:
             return {"id": host_id}
 
-        raise HTTPException(status_code=404, detail="Random Host ID not returned")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host ID not returned"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Host ID not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host ID not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random host ID"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve a random host ID"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random host ID",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve a random host ID"
+            },
+        )
 
 
 @router.get(
     "/random/slug",
     summary="Retrieve a Random Host Slug String",
     response_model=ModelsHostSlug,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Hosts"],
 )
 @router.head("/random/slug", include_in_schema=False)
@@ -360,19 +410,22 @@ async def get_random_host_slug():
         if host_slug:
             return {"slug": host_slug}
 
-        raise HTTPException(
-            status_code=404, detail="Random Host slug string not returned"
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host slug string not returned"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Host slug string not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Host slug string not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random host slug string"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random host slug string",
-        ) from None
+            content={"detail": "Unable to retrieve a random host slug string"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random host slug string"
+            },
+        )

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -8,7 +8,8 @@
 from typing import Annotated
 
 import mysql.connector
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
+from fastapi.responses import JSONResponse
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.location import Location
 
@@ -26,6 +27,7 @@ from app.models.locations import PostalAbbreviations as ModelsPostalAbbreviation
 from app.models.locations import (
     PostalAbbreviationsDetails as ModelsPostalAbbreviationsDetails,
 )
+from app.models.messages import MessageDetails
 
 router = APIRouter(prefix=f"/v{API_VERSION}/locations")
 _config = load_config()
@@ -37,6 +39,7 @@ _database_connection = mysql.connector.connect(**_database_config)
     "",
     summary="Retrieve Information for All Locations",
     response_model=ModelsLocations,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("", include_in_schema=False)
@@ -53,22 +56,26 @@ async def get_locations():
         if locations:
             return {"locations": locations}
 
-        raise HTTPException(status_code=404, detail="No locations found")
+        return JSONResponse(status_code=404, content={"detail": "No locations found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve locations from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving locations from the database",
-        ) from None
+            content={"detail": "Unable to retrieve locations from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving locations from the database"
+            },
+        )
 
 
 @router.get(
     "/id/{location_id}",
     summary="Retrieve Information by Location ID",
     response_model=ModelsLocation,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/id/{location_id}", include_in_schema=False)
@@ -87,28 +94,32 @@ async def get_location_by_id(
         if location_info:
             return location_info
 
-        raise HTTPException(
-            status_code=404, detail=f"Location ID {location_id} not found"
+        return JSONResponse(
+            status_code=404, content={"detail": f"Location ID {location_id} not found"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Location ID {location_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Location ID {location_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/slug/{location_slug}",
     summary="Retrieve Information by Location Slug String",
     response_model=ModelsLocation,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/slug/{location_slug}", include_in_schema=False)
@@ -125,29 +136,34 @@ async def get_location_by_slug(
         if location_info:
             return location_info
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Location slug string {location_slug} not found",
+            content={"detail": f"Location slug string {location_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Location slug string {location_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Location slug string {location_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/recordings",
     summary="Retrieve Information and Recordings for All Locations",
     response_model=ModelsLocationsDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/recordings", include_in_schema=False)
@@ -166,26 +182,30 @@ async def get_locations_details():
         if locations:
             return {"locations": locations}
 
-        raise HTTPException(status_code=404, detail="No locations found")
+        return JSONResponse(status_code=404, content={"detail": "No locations found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve locations from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving locations from the database",
-        ) from None
+            content={"detail": "Unable to retrieve locations from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving locations from the database"
+            },
+        )
 
 
 @router.get(
     "/recordings/id/{location_id}",
     summary="Retrieve Information and Recordings by Location ID",
     response_model=ModelsLocationDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/recordings/id/{location_id}", include_in_schema=False)
-async def get_location_recordings_by_id(
+async def get_location_details_by_id(
     location_id: Annotated[
         int, Path(title="The ID of the location to get", ge=0, lt=2**31)
     ],
@@ -203,28 +223,32 @@ async def get_location_recordings_by_id(
         if location_recordings:
             return location_recordings
 
-        raise HTTPException(
-            status_code=404, detail=f"Location ID {location_id} not found"
+        return JSONResponse(
+            status_code=404, content={"detail": f"Location ID {location_id} not found"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Location ID {location_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Location ID {location_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/recordings/random",
     summary="Retrieve Information and Recordings for a Random Location",
     response_model=ModelsLocationDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/recordings/random", include_in_schema=False)
@@ -241,30 +265,36 @@ async def get_random_location_details():
         if location_details:
             return location_details
 
-        raise HTTPException(status_code=404, detail="Random Location not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Location not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/recordings/slug/{location_slug}",
     summary="Retrieve Information and Recordings by Location Slug String",
     response_model=ModelsLocationDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/recordings/slug/{location_slug}", include_in_schema=False)
-async def get_location_recordings_by_slug(
+async def get_location_details_by_slug(
     location_slug: Annotated[str, Path(title="The slug string of the location to get")],
 ):
     """Retrieve Details for a Show Location by Location Slug String.
@@ -280,29 +310,34 @@ async def get_location_recordings_by_slug(
         if location_details:
             return location_details
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Location slug string {location_slug} not found",
+            content={"detail": f"Location slug string {location_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Location slug string {location_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Location slug string {location_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/postal-abbreviations",
     summary="Retrieve Postal Abbreviations",
     response_model=ModelsPostalAbbreviations,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/postal-abbreviations", include_in_schema=False)
@@ -320,22 +355,28 @@ async def get_postal_abbreviations() -> list[str]:
         if abbreviations:
             return list(abbreviations.keys())
 
-        raise HTTPException(status_code=404, detail="No postal abbreviations found")
+        return JSONResponse(
+            status_code=404, content={"detail": "No postal abbreviations found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve postal abbreviations"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve postal abbreviations",
-        ) from None
+            content={"detail": "Unable to retrieve postal abbreviations"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve postal abbreviations"
+            },
+        )
 
 
 @router.get(
     "/postal-abbreviations/details",
     summary="Retrieve Information for All Postal Abbreviations",
     response_model=ModelsPostalAbbreviationsDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/postal-abbreviations/details", include_in_schema=False)
@@ -353,26 +394,32 @@ async def get_postal_abbreviations_details() -> list[dict[str, str]]:
         if abbreviations:
             return {"postal_abbreviations": abbreviations}
 
-        raise HTTPException(status_code=404, detail="No postal abbreviations found")
+        return JSONResponse(
+            status_code=404, content={"detail": "No postal abbreviations found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve postal abbreviations"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve postal abbreviations",
-        ) from None
+            content={"detail": "Unable to retrieve postal abbreviations"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve postal abbreviations"
+            },
+        )
 
 
 @router.get(
     "/postal-abbreviations/details/{abbreviation}",
     summary="Retrieve Information for a Postal Abbreviation",
     response_model=ModelsPostalAbbreviationDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/postal-abbreviations/details/{abbreviation}", include_in_schema=False)
-async def get_postal_abbreviation(
+async def get_postal_abbreviation_details(
     abbreviation: Annotated[
         str, Path(title="Postal Abbreviation to retrieve information")
     ],
@@ -390,31 +437,34 @@ async def get_postal_abbreviation(
         if info:
             return info
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Postal abbreviation {abbreviation} not found",
+            content={"detail": f"Postal abbreviation {abbreviation} not found"},
         )
     except ValueError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Postal abbreviation {abbreviation} not found",
-        ) from None
+            content={"detail": f"Postal abbreviation {abbreviation} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve postal abbreviation information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve postal "
-            "abbreviaton information",
-        ) from None
+            content={"detail": "Unable to retrieve postal abbreviation information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve postal abbreviaton information"
+            },
+        )
 
 
 @router.get(
     "/random",
     summary="Retrieve Information for a Random Location",
     response_model=ModelsLocation,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/random", include_in_schema=False)
@@ -429,26 +479,32 @@ async def get_random_location():
         if location_info:
             return location_info
 
-        raise HTTPException(status_code=404, detail="Random Location not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Location not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve location information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve location information",
-        ) from None
+            content={"detail": "Unable to retrieve location information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve location information"
+            },
+        )
 
 
 @router.get(
     "/random/id",
     summary="Retrieve a Random Location ID",
     response_model=ModelsLocationID,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/random/id", include_in_schema=False)
@@ -463,26 +519,32 @@ async def get_random_location_id():
         if location_id:
             return {"id": location_id}
 
-        raise HTTPException(status_code=404, detail="Random Location ID not returned")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location ID not returned"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Location ID not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Location ID not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random location ID"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random location ID",
-        ) from None
+            content={"detail": "Unable to retrieve a random location ID"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random location ID"
+            },
+        )
 
 
 @router.get(
     "/random/slug",
     summary="Retrieve a Random Location Slug String",
     response_model=ModelsLocationSlug,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Locations"],
 )
 @router.head("/random/slug", include_in_schema=False)
@@ -497,19 +559,24 @@ async def get_random_location_slug():
         if location_slug:
             return {"slug": location_slug}
 
-        raise HTTPException(
-            status_code=404, detail="Random Location slug string not returned"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Location slug string not returned"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Location slug string not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Location slug string not returned"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random location slug string"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a location host slug string",
-        ) from None
+            content={"detail": "Unable to retrieve a random location slug string"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a location host slug string"
+            },
+        )

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -8,11 +8,13 @@
 from typing import Annotated
 
 import mysql.connector
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
+from fastapi.responses import JSONResponse
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.panelist import Panelist, PanelistDecimalScores, PanelistScores
 
 from app.config import API_VERSION, load_config
+from app.models.messages import MessageDetails
 from app.models.panelists import Panelist as ModelsPanelist
 from app.models.panelists import PanelistDetails as ModelsPanelistDetails
 from app.models.panelists import PanelistID as ModelsPanelistID
@@ -37,6 +39,7 @@ _database_connection = mysql.connector.connect(**_database_config)
     "",
     summary="Retrieve Information for All Panelists",
     response_model=ModelsPanelists,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("", include_in_schema=False)
@@ -53,22 +56,26 @@ async def get_panelists():
         if panelists:
             return {"panelists": panelists}
 
-        raise HTTPException(status_code=404, detail="No panelists found")
+        return JSONResponse(status_code=404, content={"detail": "No panelists found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelists from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving panelists from the database",
-        ) from None
+            content={"detail": "Unable to retrieve panelists from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving panelists from the database"
+            },
+        )
 
 
 @router.get(
     "/id/{panelist_id}",
     summary="Retrieve Information by Panelist ID",
     response_model=ModelsPanelist,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/id/{panelist_id}", include_in_schema=False)
@@ -87,28 +94,32 @@ async def get_panelist_by_id(
         if panelist_info:
             return panelist_info
 
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/slug/{panelist_slug}",
     summary="Retrieve Information by Panelist Slug String",
     response_model=ModelsPanelist,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/slug/{panelist_slug}", include_in_schema=False)
@@ -125,29 +136,34 @@ async def get_panelist_by_slug(
         if panelist_info:
             return panelist_info
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Panelist slug string {panelist_slug} not found",
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/details",
     summary="Retrieve Information, Statistics, and Appearances for All Panelists",
     response_model=ModelsPanelistsDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/details", include_in_schema=False)
@@ -168,22 +184,26 @@ async def get_panelists_details():
         if panelists:
             return {"panelists": panelists}
 
-        raise HTTPException(status_code=404, detail="No panelists found")
+        return JSONResponse(status_code=404, content={"detail": "No panelists found"})
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelists from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving panelists from the database",
-        ) from None
+            content={"detail": "Unable to retrieve panelists from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving panelists from the database"
+            },
+        )
 
 
 @router.get(
     "/details/id/{panelist_id}",
     summary="Retrieve Information, Statistics, and Appearances by Panelist ID",
     response_model=ModelsPanelistDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/details/id/{panelist_id}", include_in_schema=False)
@@ -207,28 +227,32 @@ async def get_panelist_details_by_id(
         if panelist_details:
             return panelist_details
 
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/details/random",
     summary="Retrieve Information and Appearances for a Random Panelist",
     response_model=ModelsPanelistDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/details/random", include_in_schema=False)
@@ -248,26 +272,32 @@ async def get_random_panelist_details():
         if panelist_details:
             return panelist_details
 
-        raise HTTPException(status_code=404, detail="Random Panelist not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Panelist not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/details/slug/{panelist_slug}",
     summary="Retrieve Information, Statistics and Appearances by Panelist by Slug String",
     response_model=ModelsPanelistDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/details/slug/{panelist_slug}", include_in_schema=False)
@@ -290,29 +320,34 @@ async def get_panelist_details_by_slug(
         if panelist_details:
             return panelist_details
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Panelist slug string {panelist_slug} not found",
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/scores/id/{panelist_id}",
     summary="Retrieve Panelist Scores for Each Appearance by Panelist ID",
     response_model=ModelsPanelistScoresList,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/scores/id/{panelist_id}", include_in_schema=False)
@@ -339,29 +374,32 @@ async def get_panelist_scores_by_id(
         if scores:
             return scores
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist ID {panelist_id} not found",
+            content={"detail": f"Scoring data for Panelist ID {panelist_id} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
     "/scores/slug/{panelist_slug}",
     summary="Retrieve Panelist Scores for Each Appearance by Panelist Slug String",
     response_model=ModelsPanelistScoresList,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/scores/slug/{panelist_slug}", include_in_schema=False)
@@ -384,23 +422,28 @@ async def get_panelist_scores_by_slug(
         if scores:
             return scores
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist slug string {panelist_slug} not found",
+            content={
+                "detail": f"Scoring data for Panelist slug string {panelist_slug} not found"
+            },
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
@@ -410,6 +453,7 @@ async def get_panelist_scores_by_slug(
         "Times It Has Been Earned by Panelist ID"
     ),
     response_model=ModelsPanelistScoresGroupedOrderedPair,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/scores/grouped-ordered-pair/id/{panelist_id}", include_in_schema=False)
@@ -439,23 +483,25 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
         if scores:
             return {"scores": scores}
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist ID {panelist_id} not found",
+            content={"detail": f"Scoring data for Panelist ID {panelist_id} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
@@ -465,6 +511,7 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
         "Times It Has Been Earned by Panelist Slug String"
     ),
     response_model=ModelsPanelistScoresGroupedOrderedPair,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head(
@@ -494,29 +541,35 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
         if scores:
             return {"scores": scores}
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist slug string {panelist_slug} not found",
+            content={
+                "detail": f"Scoring data for Panelist slug string {panelist_slug} not found"
+            },
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
     "/scores/ordered-pair/id/{panelist_id}",
     summary="Retrieve Panelist Scores as Ordered Pairs by Panelist ID",
     response_model=ModelsPanelistScoresOrderedPair,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/scores/ordered-pair/id/{panelist_id}", include_in_schema=False)
@@ -542,29 +595,32 @@ async def get_panelist_scores_ordered_pair_by_id(
         if scores:
             return {"scores": scores}
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist ID {panelist_id} not found",
+            content={"detail": f"Scoring data for Panelist ID {panelist_id} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist ID {panelist_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": f"Panelist ID {panelist_id} not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
     "/scores/ordered-pair/slug/{panelist_slug}",
     summary="Retrieve Panelist Scores as Ordered Pairs by Panelist Slug String",
     response_model=ModelsPanelistScoresOrderedPair,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/scores/ordered-pair/slug/{panelist_slug}", include_in_schema=False)
@@ -592,29 +648,35 @@ async def get_panelist_scores_ordered_pair_by_slug(
         if scores:
             return {"scores": scores}
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scoring data for Panelist slug string {panelist_slug} not found",
+            content={
+                "detail": f"Scoring data for Panelist slug string {panelist_slug} not found"
+            },
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Panelist slug string {panelist_slug} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Panelist slug string {panelist_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist scores"
-        ) from None
+        return JSONResponse(
+            status_code=500, content={"detail": "Unable to retrieve panelist scores"}
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist scores",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist scores"
+            },
+        )
 
 
 @router.get(
     "/random",
     summary="Retrieve Information for a Random Panelist",
     response_model=ModelsPanelist,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/random", include_in_schema=False)
@@ -629,26 +691,32 @@ async def get_random_panelist():
         if panelist_info:
             return panelist_info
 
-        raise HTTPException(status_code=404, detail="Random Panelist not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Panelist not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve panelist information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve panelist information",
-        ) from None
+            content={"detail": "Unable to retrieve panelist information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve panelist information"
+            },
+        )
 
 
 @router.get(
     "/random/id",
     summary="Retrieve a Random Panelist ID",
     response_model=ModelsPanelistID,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/random/id", include_in_schema=False)
@@ -663,26 +731,32 @@ async def get_random_panelist_id():
         if panelist_id:
             return {"id": panelist_id}
 
-        raise HTTPException(status_code=404, detail="Random Panelist ID not returned")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist ID not returned"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Panelist ID not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Panelist ID not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random panelist ID"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random panelist ID",
-        ) from None
+            content={"detail": "Unable to retrieve a random panelist ID"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random panelist ID"
+            },
+        )
 
 
 @router.get(
     "/random/slug",
     summary="Retrieve a Random Panelist Slug String",
     response_model=ModelsPanelistSlug,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Panelists"],
 )
 @router.head("/random/slug", include_in_schema=False)
@@ -697,19 +771,24 @@ async def get_random_panelist_slug():
         if panelist_slug:
             return {"slug": panelist_slug}
 
-        raise HTTPException(
-            status_code=404, detail="Random Panelist slug string not returned"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Panelist slug string not returned"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Panelist slug string not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Panelist slug string not returned"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random panelist slug string"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random panelist slug string",
-        ) from None
+            content={"detail": "Unable to retrieve a random panelist slug string"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random panelist slug string"
+            },
+        )

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -8,11 +8,13 @@
 from typing import Annotated
 
 import mysql.connector
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
+from fastapi.responses import JSONResponse
 from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm.scorekeeper import Scorekeeper
 
 from app.config import API_VERSION, load_config
+from app.models.messages import MessageDetails
 from app.models.scorekeepers import Scorekeeper as ModelsScorekeeper
 from app.models.scorekeepers import ScorekeeperDetails as ModelsScorekeeperDetails
 from app.models.scorekeepers import ScorekeeperID as ModelsScorekeeperID
@@ -30,6 +32,7 @@ _database_connection = mysql.connector.connect(**_database_config)
     "",
     summary="Retrieve Information for All Scorekeepers",
     response_model=ModelsScorekeepers,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("", include_in_schema=False)
@@ -46,22 +49,28 @@ async def get_scorekeepers():
         if scorekeepers:
             return {"scorekeepers": scorekeepers}
 
-        raise HTTPException(status_code=404, detail="No scorekeepers found")
+        return JSONResponse(
+            status_code=404, content={"detail": "No scorekeepers found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeepers from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving scorekeepers from the database",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeepers from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving scorekeepers from the database"
+            },
+        )
 
 
 @router.get(
     "/id/{scorekeeper_id}",
     summary="Retrieve Information by Scorekeeper ID",
     response_model=ModelsScorekeeper,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/id/{scorekeeper_id}", include_in_schema=False)
@@ -80,28 +89,34 @@ async def get_scorekeeper_by_id(
         if scorekeeper_info:
             return scorekeeper_info
 
-        raise HTTPException(
-            status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Scorekeeper ID {scorekeeper_id} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Scorekeeper ID {scorekeeper_id} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/slug/{scorekeeper_slug}",
     summary="Retrieve Information by Scorekeeper Slug String",
     response_model=ModelsScorekeeper,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/slug/{scorekeeper_slug}", include_in_schema=False)
@@ -120,30 +135,34 @@ async def get_scorekeeper_by_slug(
         if scorekeeper_info:
             return scorekeeper_info
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
+            content={"detail": f"Scorekeeper slug string {scorekeeper_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
-        ) from None
+            content={"detail": f"Scorekeeper slug string {scorekeeper_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/details",
     summary="Retrieve Information and Appearances for All Scorekeepers",
     response_model=ModelsScorekeepersDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/details", include_in_schema=False)
@@ -162,22 +181,28 @@ async def get_scorekeepers_details():
         if scorekeepers:
             return {"scorekeepers": scorekeepers}
 
-        raise HTTPException(status_code=404, detail="No scorekeepers found")
+        return JSONResponse(
+            status_code=404, content={"detail": "No scorekeepers found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeepers from the database"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while retrieving scorekeepers from the database",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeepers from the database"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while retrieving scorekeepers from the database"
+            },
+        )
 
 
 @router.get(
     "/details/id/{scorekeeper_id}",
     summary="Retrieve Information and Appearances by Scorekeeper ID",
     response_model=ModelsScorekeeperDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/details/id/{scorekeeper_id}", include_in_schema=False)
@@ -199,28 +224,34 @@ async def get_scorekeeper_details_by_id(
         if scorekeeper_details:
             return scorekeeper_details
 
-        raise HTTPException(
-            status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Scorekeeper ID {scorekeeper_id} not found"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail=f"Scorekeeper ID {scorekeeper_id} not found"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"Scorekeeper ID {scorekeeper_id} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/details/random",
     summary="Retrieve Information and Appearances for a Random Scorekeeper",
     response_model=ModelsScorekeeperDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/details/random", include_in_schema=False)
@@ -238,26 +269,32 @@ async def get_random_scorekeeper_details():
         if scorekeeper_details:
             return scorekeeper_details
 
-        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/details/slug/{scorekeeper_slug}",
     summary="Retrieve Information and Appearances by Scorekeeper by Slug String",
     response_model=ModelsScorekeeperDetails,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/details/slug/{scorekeeper_slug}", include_in_schema=False)
@@ -281,30 +318,34 @@ async def get_scorekeeper_details_by_slug(
         if scorekeeper_details:
             return scorekeeper_details
 
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
+            content={"detail": f"Scorekeeper slug string {scorekeeper_slug} not found"},
         )
     except ValueError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=404,
-            detail=f"Scorekeeper slug string {scorekeeper_slug} not found",
-        ) from None
+            content={"detail": f"Scorekeeper slug string {scorekeeper_slug} not found"},
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/random",
     summary="Retrieve Information for a Random Scorekeeper",
     response_model=ModelsScorekeeper,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/random", include_in_schema=False)
@@ -319,26 +360,32 @@ async def get_random_scorekeeper():
         if scorekeeper_info:
             return scorekeeper_info
 
-        raise HTTPException(status_code=404, detail="Random Scorekeeper not found")
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper not found"}
+        )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper not found"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper not found"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve scorekeeper information"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve scorekeeper information",
-        ) from None
+            content={"detail": "Unable to retrieve scorekeeper information"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve scorekeeper information"
+            },
+        )
 
 
 @router.get(
     "/random/id",
     summary="Retrieve a Random Scorekeeper ID",
     response_model=ModelsScorekeeperID,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/random/id", include_in_schema=False)
@@ -353,28 +400,32 @@ async def get_random_scorekeeper_id():
         if scorekeeper_id:
             return {"id": scorekeeper_id}
 
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper ID not returned"
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper ID not returned"}
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper ID not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404, content={"detail": "Random Scorekeeper ID not returned"}
+        )
     except ProgrammingError:
-        raise HTTPException(
-            status_code=500, detail="Unable to retrieve a random scorekeeper ID"
-        ) from None
-    except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random scorekeeper ID",
-        ) from None
+            content={"detail": "Unable to retrieve a random scorekeeper ID"},
+        )
+    except DatabaseError:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Database error occurred while trying to retrieve a random scorekeeper ID"
+            },
+        )
 
 
 @router.get(
     "/random/slug",
     summary="Retrieve a Random Scorekeeper Slug String",
     response_model=ModelsScorekeeperSlug,
+    responses={404: {"model": MessageDetails}, 500: {"model": MessageDetails}},
     tags=["Scorekeepers"],
 )
 @router.head("/random/slug", include_in_schema=False)
@@ -389,20 +440,24 @@ async def get_random_scorekeeper_slug():
         if scorekeeper_slug:
             return {"slug": scorekeeper_slug}
 
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper slug string not returned"
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Scorekeeper slug string not returned"},
         )
     except ValueError:
-        raise HTTPException(
-            status_code=404, detail="Random Scorekeeper slug string not returned"
-        ) from None
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Random Scorekeeper slug string not returned"},
+        )
     except ProgrammingError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Unable to retrieve a random scorekeeper slug string",
-        ) from None
+            content={"detail": "Unable to retrieve a random scorekeeper slug string"},
+        )
     except DatabaseError:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail="Database error occurred while trying to retrieve a random scorekeeper slug string",
-        ) from None
+            content={
+                "detail": "Database error occurred while trying to retrieve a random scorekeeper slug string"
+            },
+        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,9 @@ ruff==0.9.3
 pytest==8.3.4
 pytest-cov==6.0.0
 
-pydantic==2.10.6
-fastapi==0.115.8
-uvicorn[standard]==0.34.0
+pydantic==2.11.4
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
 gunicorn==23.0.0
 httpx==0.28.1
 aiofiles==24.1.0
@@ -12,4 +12,4 @@ jinja2==3.1.6
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.17.2
+wwdtm==2.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pydantic==2.10.6
-fastapi==0.115.8
-uvicorn[standard]==0.34.0
+pydantic==2.11.4
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
 gunicorn==23.0.0
 httpx==0.28.1
 aiofiles==24.1.0
@@ -8,4 +8,4 @@ jinja2==3.1.6
 email-validator==2.2.0
 requests==2.32.3
 
-wwdtm==2.17.2
+wwdtm==2.18.2

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_guests():
+def test_get_guests():
     """Test /v2.0/guests route."""
     response = client.get(f"/v{API_VERSION}/guests")
     guests = response.json()
@@ -27,7 +27,7 @@ def test_guests():
 
 
 @pytest.mark.parametrize("guest_id", [54])
-def test_guests_id(guest_id: int):
+def test_get_guest_by_id(guest_id: int):
     """Test /v2.0/guests/id/{guest_id} route."""
     response = client.get(f"/v{API_VERSION}/guests/id/{guest_id}")
     guest = response.json()
@@ -39,8 +39,18 @@ def test_guests_id(guest_id: int):
     assert "slug" in guest
 
 
+@pytest.mark.parametrize("guest_id", [0])
+def test_get_guest_by_id_not_found(guest_id: int):
+    """Test /v2.0/guests/id/{guest_id} route."""
+    response = client.get(f"/v{API_VERSION}/guests/id/{guest_id}")
+    guest = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in guest
+
+
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
-def test_guests_slug(guest_slug: str):
+def test_get_guest_by_slug(guest_slug: str):
     """Test /v2.0/guests/slug/{guest_slug} route."""
     response = client.get(f"/v{API_VERSION}/guests/slug/{guest_slug}")
     guest = response.json()
@@ -52,7 +62,17 @@ def test_guests_slug(guest_slug: str):
     assert guest["slug"] == guest_slug
 
 
-def test_guests_details():
+@pytest.mark.parametrize("guest_slug", ["-abcdef"])
+def test_get_guest_by_slug_not_found(guest_slug: str):
+    """Test /v2.0/guests/slug/{guest_slug} route."""
+    response = client.get(f"/v{API_VERSION}/guests/slug/{guest_slug}")
+    guest = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in guest
+
+
+def test_get_guests_details():
     """Test /v2.0/guests/details route."""
     response = client.get(f"/v{API_VERSION}/guests/details")
     guests = response.json()
@@ -66,7 +86,7 @@ def test_guests_details():
 
 
 @pytest.mark.parametrize("guest_id", [54])
-def test_guests_details_id(guest_id: int):
+def test_get_guest_details_by_id(guest_id: int):
     """Test /v2.0/guests/details/id/{guest_id} route."""
     response = client.get(f"/v{API_VERSION}/guests/details/id/{guest_id}")
     guest = response.json()
@@ -79,8 +99,30 @@ def test_guests_details_id(guest_id: int):
     assert "appearances" in guest
 
 
+@pytest.mark.parametrize("guest_id", [0])
+def test_get_guest_details_by_id_not_found(guest_id: int):
+    """Test /v2.0/guests/details/id/{guest_id} route."""
+    response = client.get(f"/v{API_VERSION}/guests/details/id/{guest_id}")
+    guest = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in guest
+
+
+def test_get_random_guest_details():
+    """Test /v2.0/guests/details/random route."""
+    response = client.get(f"/v{API_VERSION}/guests/details/random")
+    guest = response.json()
+
+    assert response.status_code == 200
+    assert "id" in guest
+    assert "name" in guest
+    assert "slug" in guest
+    assert "appearances" in guest
+
+
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
-def test_guests_details_slug(guest_slug: str):
+def test_get_guest_details_by_slug(guest_slug: str):
     """Test /v2.0/guests/details/slug/{guest_slug} route."""
     response = client.get(f"/v{API_VERSION}/guests/details/slug/{guest_slug}")
     guest = response.json()
@@ -93,7 +135,17 @@ def test_guests_details_slug(guest_slug: str):
     assert "appearances" in guest
 
 
-def test_guests_random():
+@pytest.mark.parametrize("guest_slug", ["-abcdef"])
+def test_get_guest_details_by_slug_not_found(guest_slug: str):
+    """Test /v2.0/guests/details/slug/{guest_slug} route."""
+    response = client.get(f"/v{API_VERSION}/guests/details/slug/{guest_slug}")
+    guest = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in guest
+
+
+def test_get_random_guest():
     """Test /v2.0/guests/random route."""
     response = client.get(f"/v{API_VERSION}/guests/random")
     guest = response.json()
@@ -104,19 +156,7 @@ def test_guests_random():
     assert "slug" in guest
 
 
-def test_guests_random_details():
-    """Test /v2.0/guests/details/random route."""
-    response = client.get(f"/v{API_VERSION}/guests/details/random")
-    guest = response.json()
-
-    assert response.status_code == 200
-    assert "id" in guest
-    assert "name" in guest
-    assert "slug" in guest
-    assert "appearances" in guest
-
-
-def test_guests_random_id():
+def test_get_random_guest_id():
     """Test /v2.0/guests/random/id route."""
     response = client.get(f"/v{API_VERSION}/guests/random/id")
     _id = response.json()
@@ -126,7 +166,7 @@ def test_guests_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_guests_random_slug():
+def test_get_randon_guest_slug():
     """Test /v2.0/guests/random/slug route."""
     response = client.get(f"/v{API_VERSION}/guests/random/slug")
     _slug = response.json()

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_hosts():
+def test_get_hosts():
     """Test /v2.0/hosts route."""
     response = client.get(f"/v{API_VERSION}/hosts")
     hosts = response.json()
@@ -28,7 +28,7 @@ def test_hosts():
 
 
 @pytest.mark.parametrize("host_id", [2])
-def test_hosts_id(host_id: int):
+def test_get_host_by_id(host_id: int):
     """Test /v2.0/hosts/id/{host_id} route."""
     response = client.get(f"/v{API_VERSION}/hosts/id/{host_id}")
     host = response.json()
@@ -41,8 +41,18 @@ def test_hosts_id(host_id: int):
     assert "slug" in host
 
 
+@pytest.mark.parametrize("host_id", [65535])
+def test_get_host_by_id_not_found(host_id: int):
+    """Test /v2.0/hosts/id/{host_id} route."""
+    response = client.get(f"/v{API_VERSION}/hosts/id/{host_id}")
+    host = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in host
+
+
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
-def test_hosts_slug(host_slug: str):
+def test_get_host_by_slug(host_slug: str):
     """Test /v2.0/hosts/slug/{host_slug} route."""
     response = client.get(f"/v{API_VERSION}/hosts/slug/{host_slug}")
     host = response.json()
@@ -55,7 +65,17 @@ def test_hosts_slug(host_slug: str):
     assert host["slug"] == host_slug
 
 
-def test_hosts_details():
+@pytest.mark.parametrize("host_slug", ["-abcdef"])
+def test_get_host_by_slug_not_found(host_slug: str):
+    """Test /v2.0/hosts/slug/{host_slug} route."""
+    response = client.get(f"/v{API_VERSION}/hosts/slug/{host_slug}")
+    host = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in host
+
+
+def test_get_hosts_details():
     """Test /v2.0/hosts/details route."""
     response = client.get(f"/v{API_VERSION}/hosts/details")
     hosts = response.json()
@@ -70,7 +90,7 @@ def test_hosts_details():
 
 
 @pytest.mark.parametrize("host_id", [2])
-def test_hosts_details_id(host_id: int):
+def test_get_host_details_by_id(host_id: int):
     """Test /v2.0/hosts/details/id/{host_id} route."""
     response = client.get(f"/v{API_VERSION}/hosts/details/id/{host_id}")
     host = response.json()
@@ -84,8 +104,31 @@ def test_hosts_details_id(host_id: int):
     assert "appearances" in host
 
 
+@pytest.mark.parametrize("host_id", [0])
+def test_get_host_details_by_id_not_found(host_id: int):
+    """Test /v2.0/hosts/details/id/{host_id} route."""
+    response = client.get(f"/v{API_VERSION}/hosts/details/id/{host_id}")
+    host = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in host
+
+
+def test_get_random_host_details():
+    """Test /v2.0/hosts/details/random route."""
+    response = client.get(f"/v{API_VERSION}/hosts/details/random")
+    host = response.json()
+
+    assert response.status_code == 200
+    assert "id" in host
+    assert "name" in host
+    assert "pronouns" in host
+    assert "slug" in host
+    assert "appearances" in host
+
+
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
-def test_hosts_details_slug(host_slug: str):
+def test_get_host_details_by_slug(host_slug: str):
     """Test /v2.0/hosts/details/slug/{host_slug} route."""
     response = client.get(f"/v{API_VERSION}/hosts/details/slug/{host_slug}")
     host = response.json()
@@ -99,7 +142,17 @@ def test_hosts_details_slug(host_slug: str):
     assert "appearances" in host
 
 
-def test_hosts_random():
+@pytest.mark.parametrize("host_slug", ["-abcdef"])
+def test_get_host_details_by_slug_not_found(host_slug: str):
+    """Test /v2.0/hosts/details/slug/{host_slug} route."""
+    response = client.get(f"/v{API_VERSION}/hosts/details/slug/{host_slug}")
+    host = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in host
+
+
+def test_get_random_host():
     """Test /v2.0/hosts/random route."""
     response = client.get(f"/v{API_VERSION}/hosts/random")
     host = response.json()
@@ -111,20 +164,7 @@ def test_hosts_random():
     assert "slug" in host
 
 
-def test_hosts_random_details():
-    """Test /v2.0/hosts/details/random route."""
-    response = client.get(f"/v{API_VERSION}/hosts/details/random")
-    host = response.json()
-
-    assert response.status_code == 200
-    assert "id" in host
-    assert "name" in host
-    assert "pronouns" in host
-    assert "slug" in host
-    assert "appearances" in host
-
-
-def test_hosts_random_id():
+def test_get_random_host_id():
     """Test /v2.0/hosts/random/id route."""
     response = client.get(f"/v{API_VERSION}/hosts/random/id")
     _id = response.json()
@@ -134,7 +174,7 @@ def test_hosts_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_hosts_random_slug():
+def test_get_random_host_slug():
     """Test /v2.0/hosts/random/slug route."""
     response = client.get(f"/v{API_VERSION}/hosts/random/slug")
     _slug = response.json()

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -15,7 +15,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_locations():
+def test_get_locations():
     """Test /v2.0/locations route."""
     response = client.get(f"/v{API_VERSION}/locations")
     locations = response.json()
@@ -33,7 +33,7 @@ def test_locations():
 
 
 @pytest.mark.parametrize("location_id", [32, 148])
-def test_locations_id(location_id: int):
+def test_get_location_by_id(location_id: int):
     """Test /v2.0/locations/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/id/{location_id}")
     location = response.json()
@@ -51,11 +51,21 @@ def test_locations_id(location_id: int):
         assert "longitude" in location["coordinates"]
 
 
+@pytest.mark.parametrize("location_id", [0])
+def test_get_location_by_id_not_found(location_id: int):
+    """Test /v2.0/locations/id/{location_id} route."""
+    response = client.get(f"/v{API_VERSION}/locations/id/{location_id}")
+    location = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in location
+
+
 @pytest.mark.parametrize(
     "location_slug",
     ["arlene-schnitzer-concert-hall-portland-or", "home-remote-studios"],
 )
-def test_locations_slug(location_slug: str):
+def test_get_location_by_slug(location_slug: str):
     """Test /v2.0/locations/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/slug/{location_slug}")
     location = response.json()
@@ -72,7 +82,17 @@ def test_locations_slug(location_slug: str):
         assert "longitude" in location["coordinates"]
 
 
-def test_locations_recordings():
+@pytest.mark.parametrize("location_slug", ["-abcdef"])
+def test_get_location_by_slug_not_found(location_slug: str):
+    """Test /v2.0/locations/slug/{location_slug} route."""
+    response = client.get(f"/v{API_VERSION}/locations/slug/{location_slug}")
+    location = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in location
+
+
+def test_get_locations_details():
     """Test /v2.0/locations/recordings route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings")
     locations = response.json()
@@ -92,7 +112,7 @@ def test_locations_recordings():
 
 
 @pytest.mark.parametrize("location_id", [32, 148])
-def test_locations_recordings_id(location_id: int):
+def test_get_location_details_by_id(location_id: int):
     """Test /v2.0/locations/recordings/id/{location_id} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/id/{location_id}")
     location = response.json()
@@ -110,11 +130,33 @@ def test_locations_recordings_id(location_id: int):
     assert "recordings" in location
 
 
+@pytest.mark.parametrize("location_id", [0])
+def test_get_location_details_by_id_not_found(location_id: int):
+    """Test /v2.0/locations/recordings/id/{location_id} route."""
+    response = client.get(f"/v{API_VERSION}/locations/recordings/id/{location_id}")
+    location = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in location
+
+
+def test_get_random_location_details():
+    """Test /v2.0/locations/recordings/random route."""
+    response = client.get(f"/v{API_VERSION}/locations/recordings/random")
+    location = response.json()
+
+    assert response.status_code == 200
+    assert "id" in location
+    assert "venue" in location
+    assert "slug" in location
+    assert "recordings" in location
+
+
 @pytest.mark.parametrize(
     "location_slug",
     ["arlene-schnitzer-concert-hall-portland-or", "home-remote-studios"],
 )
-def test_locations_recordings_slug(location_slug: str):
+def test_get_location_details_by_slug(location_slug: str):
     """Test /v2.0/locations/recordings/slug/{location_slug} route."""
     response = client.get(f"/v{API_VERSION}/locations/recordings/slug/{location_slug}")
     location = response.json()
@@ -132,7 +174,17 @@ def test_locations_recordings_slug(location_slug: str):
     assert "recordings" in location
 
 
-def test_locations_postal_abbreviations():
+@pytest.mark.parametrize("location_slug", ["-abcdef"])
+def test_get_location_details_by_slug_not_found(location_slug: str):
+    """Test /v2.0/locations/recordings/slug/{location_slug} route."""
+    response = client.get(f"/v{API_VERSION}/locations/recordings/slug/{location_slug}")
+    location = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in location
+
+
+def test_get_postal_abbreviations():
     """Test /v2.0/locations/postal-abbreviations route."""
     response = client.get(f"/v{API_VERSION}/locations/postal-abbreviations")
     abbreviations = response.json()
@@ -142,7 +194,7 @@ def test_locations_postal_abbreviations():
     assert isinstance(abbreviations[0], str)
 
 
-def test_locations_postal_abbreviations_details_all():
+def test_get_postal_abbreviations_details():
     """Test /v2.0/locations/postal-abbreviations/details route."""
     response = client.get(f"/v{API_VERSION}/locations/postal-abbreviations/details")
     abbreviations = response.json()
@@ -157,7 +209,7 @@ def test_locations_postal_abbreviations_details_all():
 
 
 @pytest.mark.parametrize("abbreviation", ["OR", "DC"])
-def test_locations_postal_abbreviations_details(abbreviation: str):
+def test_get_postal_abbreviation_details(abbreviation: str):
     """Test /v2.0/locations/postal-abbreviations/details route."""
     response = client.get(
         f"/v{API_VERSION}/locations/postal-abbreviations/details/{abbreviation}"
@@ -171,7 +223,19 @@ def test_locations_postal_abbreviations_details(abbreviation: str):
     assert "country" in info
 
 
-def test_locations_random():
+@pytest.mark.parametrize("abbreviation", ["-XYZ"])
+def test_get_postal_abbreviation_details_not_found(abbreviation: str):
+    """Test /v2.0/locations/postal-abbreviations/details route."""
+    response = client.get(
+        f"/v{API_VERSION}/locations/postal-abbreviations/details/{abbreviation}"
+    )
+    info = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in info
+
+
+def test_get_random_location():
     """Test /v2.0/locations/random route."""
     response = client.get(f"/v{API_VERSION}/locations/random")
     location = response.json()
@@ -182,19 +246,7 @@ def test_locations_random():
     assert "slug" in location
 
 
-def test_locations_random_details():
-    """Test /v2.0/locations/recordings/random route."""
-    response = client.get(f"/v{API_VERSION}/locations/recordings/random")
-    location = response.json()
-
-    assert response.status_code == 200
-    assert "id" in location
-    assert "venue" in location
-    assert "slug" in location
-    assert "recordings" in location
-
-
-def test_locations_random_id():
+def test_get_random_location_id():
     """Test /v2.0/locations/random/id route."""
     response = client.get(f"/v{API_VERSION}/locations/random/id")
     _id = response.json()
@@ -204,7 +256,7 @@ def test_locations_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_locations_random_slug():
+def test_get_random_location_slug():
     """Test /v2.0/locations/random/slug route."""
     response = client.get(f"/v{API_VERSION}/locations/random/slug")
     _slug = response.json()

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_panelists():
+def test_get_panelists():
     """Test /v2.0/panelists route."""
     response = client.get(f"/v{API_VERSION}/panelists")
     panelists = response.json()
@@ -28,7 +28,7 @@ def test_panelists():
 
 
 @pytest.mark.parametrize("panelist_id", [30])
-def test_panelists_id(panelist_id: int):
+def test_get_panelist_by_id(panelist_id: int):
     """Test /v2.0/panelists/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/id/{panelist_id}")
     panelist = response.json()
@@ -41,8 +41,18 @@ def test_panelists_id(panelist_id: int):
     assert "slug" in panelist
 
 
+@pytest.mark.parametrize("panelist_id", [0])
+def test_get_panelist_by_id_not_found(panelist_id: int):
+    """Test /v2.0/panelists/id/{panelist_id} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/id/{panelist_id}")
+    panelist = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in panelist
+
+
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
-def test_panelists_slug(panelist_slug: str):
+def test_get_panelist_by_slug(panelist_slug: str):
     """Test /v2.0/panelists/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/slug/{panelist_slug}")
     panelist = response.json()
@@ -55,7 +65,17 @@ def test_panelists_slug(panelist_slug: str):
     assert panelist["slug"] == panelist_slug
 
 
-def test_panelists_details():
+@pytest.mark.parametrize("panelist_slug", ["-abcdef"])
+def test_get_panelist_by_slug_not_found(panelist_slug: str):
+    """Test /v2.0/panelists/slug/{panelist_slug} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/slug/{panelist_slug}")
+    panelist = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in panelist
+
+
+def test_get_panelists_details():
     """Test /v2.0/panelists/details route."""
     response = client.get(f"/v{API_VERSION}/panelists/details")
     panelists = response.json()
@@ -70,7 +90,7 @@ def test_panelists_details():
 
 
 @pytest.mark.parametrize("panelist_id", [30])
-def test_panelists_details_id(panelist_id: int):
+def test_get_panelist_details_by_id(panelist_id: int):
     """Test /v2.0/panelists/details/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/details/id/{panelist_id}")
     panelist = response.json()
@@ -84,8 +104,31 @@ def test_panelists_details_id(panelist_id: int):
     assert "appearances" in panelist
 
 
+@pytest.mark.parametrize("panelist_id", [0])
+def test_get_panelist_details_by_id_not_found(panelist_id: int):
+    """Test /v2.0/panelists/details/id/{panelist_id} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/details/id/{panelist_id}")
+    panelist = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in panelist
+
+
+def test_get_random_panelist_details():
+    """Test /v2.0/panelists/details/random route."""
+    response = client.get(f"/v{API_VERSION}/panelists/details/random")
+    panelist = response.json()
+
+    assert response.status_code == 200
+    assert "id" in panelist
+    assert "name" in panelist
+    assert "pronouns" in panelist
+    assert "slug" in panelist
+    assert "appearances" in panelist
+
+
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
-def test_panelists_details_slug(panelist_slug: str):
+def test_get_panelist_details_by_slug(panelist_slug: str):
     """Test /v2.0/panelists/details/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/details/slug/{panelist_slug}")
     panelist = response.json()
@@ -99,8 +142,18 @@ def test_panelists_details_slug(panelist_slug: str):
     assert "appearances" in panelist
 
 
+@pytest.mark.parametrize("panelist_slug", ["-abcdef"])
+def test_get_panelist_details_by_slug_not_found(panelist_slug: str):
+    """Test /v2.0/panelists/details/slug/{panelist_slug} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/details/slug/{panelist_slug}")
+    panelist = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in panelist
+
+
 @pytest.mark.parametrize("panelist_id", [30])
-def test_panelists_scores_id(panelist_id: int):
+def test_get_panelist_scores_by_id(panelist_id: int):
     """Test /v2.0/panelists/scores/id/{panelist_id} route."""
     response = client.get(f"/v{API_VERSION}/panelists/scores/id/{panelist_id}")
     scores = response.json()
@@ -109,8 +162,18 @@ def test_panelists_scores_id(panelist_id: int):
     assert "scores" in scores
 
 
+@pytest.mark.parametrize("panelist_id", [0])
+def test_get_panelist_scores_by_id_not_found(panelist_id: int):
+    """Test /v2.0/panelists/scores/id/{panelist_id} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/scores/id/{panelist_id}")
+    scores = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scores
+
+
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
-def test_panelists_scores_slug(panelist_slug: str):
+def test_get_panelist_scores_by_slug(panelist_slug: str):
     """Test /v2.0/panelists/scores/slug/{panelist_slug} route."""
     response = client.get(f"/v{API_VERSION}/panelists/scores/slug/{panelist_slug}")
     scores = response.json()
@@ -119,32 +182,18 @@ def test_panelists_scores_slug(panelist_slug: str):
     assert "scores" in scores
 
 
-@pytest.mark.parametrize("panelist_id", [30])
-def test_panelists_scores_ordered_pair_id(panelist_id: int):
-    """Test /v2.0/panelists/scores/ordered-pair/id/{panelist_id} route."""
-    response = client.get(
-        f"/v{API_VERSION}/panelists/scores/ordered-pair/id/{panelist_id}"
-    )
+@pytest.mark.parametrize("panelist_slug", ["-abcdef"])
+def test_get_panelist_scores_by_slug_not_found(panelist_slug: str):
+    """Test /v2.0/panelists/scores/slug/{panelist_slug} route."""
+    response = client.get(f"/v{API_VERSION}/panelists/scores/slug/{panelist_slug}")
     scores = response.json()
 
-    assert response.status_code == 200
-    assert "scores" in scores
-
-
-@pytest.mark.parametrize("panelist_slug", ["faith-salie"])
-def test_panelists_scores_ordered_pair_slug(panelist_slug: str):
-    """Test /v2.0/panelists/scores/ordered-pair/slug/{panelist_slug} route."""
-    response = client.get(
-        f"/v{API_VERSION}/panelists/scores/ordered-pair/slug/{panelist_slug}"
-    )
-    scores = response.json()
-
-    assert response.status_code == 200
-    assert "scores" in scores
+    assert response.status_code == 404
+    assert "detail" in scores
 
 
 @pytest.mark.parametrize("panelist_id", [30])
-def test_panelists_scores_grouped_ordered_pair_id(panelist_id: int):
+def test_get_panelist_scores_grouped_ordered_pair_by_id(panelist_id: int):
     """Test /v2.0/panelists/scores/grouped-ordered-pair/id/{panelist_id} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/id/{panelist_id}"
@@ -155,8 +204,20 @@ def test_panelists_scores_grouped_ordered_pair_id(panelist_id: int):
     assert "scores" in scores
 
 
+@pytest.mark.parametrize("panelist_id", [0])
+def test_get_panelist_scores_grouped_ordered_pair_by_id_not_found(panelist_id: int):
+    """Test /v2.0/panelists/scores/grouped-ordered-pair/id/{panelist_id} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/id/{panelist_id}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scores
+
+
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
-def test_panelists_scores_grouped_ordered_pair_slug(panelist_slug: str):
+def test_get_panelist_scores_grouped_ordered_pair_by_slug(panelist_slug: str):
     """Test /v2.0/panelists/scores/grouped-ordered-pair/slug/{panelist_slug} route."""
     response = client.get(
         f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/slug/{panelist_slug}"
@@ -167,7 +228,67 @@ def test_panelists_scores_grouped_ordered_pair_slug(panelist_slug: str):
     assert "scores" in scores
 
 
-def test_panelists_random():
+@pytest.mark.parametrize("panelist_slug", ["-abcdef"])
+def test_get_panelist_scores_grouped_ordered_pair_by_slug_not_found(panelist_slug: str):
+    """Test /v2.0/panelists/scores/grouped-ordered-pair/slug/{panelist_slug} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/grouped-ordered-pair/slug/{panelist_slug}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scores
+
+
+@pytest.mark.parametrize("panelist_id", [30])
+def test_get_panelists_scores_ordered_pair_by_id(panelist_id: int):
+    """Test /v2.0/panelists/scores/ordered-pair/id/{panelist_id} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/ordered-pair/id/{panelist_id}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 200
+    assert "scores" in scores
+
+
+@pytest.mark.parametrize("panelist_id", [0])
+def test_get_panelists_scores_ordered_pair_by_id_not_found(panelist_id: int):
+    """Test /v2.0/panelists/scores/ordered-pair/id/{panelist_id} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/ordered-pair/id/{panelist_id}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scores
+
+
+@pytest.mark.parametrize("panelist_slug", ["faith-salie"])
+def test_get_panelists_scores_ordered_pair_by_slug(panelist_slug: str):
+    """Test /v2.0/panelists/scores/ordered-pair/slug/{panelist_slug} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/ordered-pair/slug/{panelist_slug}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 200
+    assert "scores" in scores
+
+
+@pytest.mark.parametrize("panelist_slug", ["-abcdef"])
+def test_get_panelists_scores_ordered_pair_by_slug_not_found(panelist_slug: str):
+    """Test /v2.0/panelists/scores/ordered-pair/slug/{panelist_slug} route."""
+    response = client.get(
+        f"/v{API_VERSION}/panelists/scores/ordered-pair/slug/{panelist_slug}"
+    )
+    scores = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scores
+
+
+def test_get_random_panelist():
     """Test /v2.0/panelists/random route."""
     response = client.get(f"/v{API_VERSION}/panelists/random")
     panelist = response.json()
@@ -179,20 +300,7 @@ def test_panelists_random():
     assert "slug" in panelist
 
 
-def test_panelists_random_details():
-    """Test /v2.0/panelists/details/random route."""
-    response = client.get(f"/v{API_VERSION}/panelists/details/random")
-    panelist = response.json()
-
-    assert response.status_code == 200
-    assert "id" in panelist
-    assert "name" in panelist
-    assert "pronouns" in panelist
-    assert "slug" in panelist
-    assert "appearances" in panelist
-
-
-def test_panelists_random_id():
+def test_get_random_panelist_id():
     """Test /v2.0/panelists/random/id route."""
     response = client.get(f"/v{API_VERSION}/panelists/random/id")
     _id = response.json()
@@ -202,7 +310,7 @@ def test_panelists_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_panelists_random_slug():
+def test_get_panelist_slug():
     """Test /v2.0/panelists/random/slug route."""
     response = client.get(f"/v{API_VERSION}/panelists/random/slug")
     _slug = response.json()

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_pronouns():
+def test_get_pronouns():
     """Test /v2.0/pronouns route."""
     response = client.get(f"/v{API_VERSION}/pronouns")
     pronouns = response.json()
@@ -26,7 +26,7 @@ def test_pronouns():
 
 
 @pytest.mark.parametrize("pronouns_id", [1])
-def test_pronouns_id(pronouns_id: int):
+def test_get_pronouns_by_id(pronouns_id: int):
     """Test /v2.0/pronouns/id/{pronouns_id} route."""
     response = client.get(f"/v{API_VERSION}/pronouns/id/{pronouns_id}")
     pronouns_info = response.json()
@@ -35,3 +35,13 @@ def test_pronouns_id(pronouns_id: int):
     assert "id" in pronouns_info
     assert pronouns_info["id"] == pronouns_id
     assert "pronouns" in pronouns_info
+
+
+@pytest.mark.parametrize("pronouns_id", [0])
+def test_get_pronouns_by_id_not_found(pronouns_id: int):
+    """Test /v2.0/pronouns/id/{pronouns_id} route."""
+    response = client.get(f"/v{API_VERSION}/pronouns/id/{pronouns_id}")
+    pronouns_info = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in pronouns_info

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_scorekeepers():
+def test_get_scorekeepers():
     """Test /v2.0/scorekeepers route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers")
     scorekeepers = response.json()
@@ -28,7 +28,7 @@ def test_scorekeepers():
 
 
 @pytest.mark.parametrize("scorekeeper_id", [11])
-def test_scorekeepers_id(scorekeeper_id: int):
+def test_get_scorekeeper_by_id(scorekeeper_id: int):
     """Test /v2.0/scorekeepers/id/{scorekeeper_id} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/id/{scorekeeper_id}")
     scorekeeper = response.json()
@@ -41,8 +41,18 @@ def test_scorekeepers_id(scorekeeper_id: int):
     assert "slug" in scorekeeper
 
 
+@pytest.mark.parametrize("scorekeeper_id", [0])
+def test_get_scorekeeper_by_id_not_found(scorekeeper_id: int):
+    """Test /v2.0/scorekeepers/id/{scorekeeper_id} route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/id/{scorekeeper_id}")
+    scorekeeper = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scorekeeper
+
+
 @pytest.mark.parametrize("scorekeeper_slug", ["bill-kurtis"])
-def test_scorekeepers_slug(scorekeeper_slug: str):
+def test_get_scorekeeper_by_slug(scorekeeper_slug: str):
     """Test /v2.0/scorekeepers/slug/{scorekeeper_slug} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/slug/{scorekeeper_slug}")
     scorekeeper = response.json()
@@ -55,7 +65,17 @@ def test_scorekeepers_slug(scorekeeper_slug: str):
     assert scorekeeper["slug"] == scorekeeper_slug
 
 
-def test_scorekeepers_details():
+@pytest.mark.parametrize("scorekeeper_slug", ["-abcdef"])
+def test_get_scorekeeper_by_slug_not_found(scorekeeper_slug: str):
+    """Test /v2.0/scorekeepers/slug/{scorekeeper_slug} route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/slug/{scorekeeper_slug}")
+    scorekeeper = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scorekeeper
+
+
+def test_get_scorekeepers_details():
     """Test /v2.0/scorekeepers/details route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/details")
     scorekeepers = response.json()
@@ -70,7 +90,7 @@ def test_scorekeepers_details():
 
 
 @pytest.mark.parametrize("scorekeeper_id", [11])
-def test_scorekeepers_details_id(scorekeeper_id: int):
+def test_get_scorekeeper_details_by_id(scorekeeper_id: int):
     """Test /v2.0/scorekeepers/details/id/{scorekeeper_id} route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/details/id/{scorekeeper_id}")
     scorekeeper = response.json()
@@ -84,8 +104,31 @@ def test_scorekeepers_details_id(scorekeeper_id: int):
     assert "appearances" in scorekeeper
 
 
+@pytest.mark.parametrize("scorekeeper_id", [0])
+def test_get_scorekeeper_details_by_id_not_found(scorekeeper_id: int):
+    """Test /v2.0/scorekeepers/details/id/{scorekeeper_id} route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/details/id/{scorekeeper_id}")
+    scorekeeper = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scorekeeper
+
+
+def test_get_random_scorekeeper_details():
+    """Test /v2.0/scorekeepers/details/random route."""
+    response = client.get(f"/v{API_VERSION}/scorekeepers/details/random")
+    scorekeeper = response.json()
+
+    assert response.status_code == 200
+    assert "id" in scorekeeper
+    assert "name" in scorekeeper
+    assert "pronouns" in scorekeeper
+    assert "slug" in scorekeeper
+    assert "appearances" in scorekeeper
+
+
 @pytest.mark.parametrize("scorekeeper_slug", ["bill-kurtis"])
-def test_scorekeepers_details_slug(scorekeeper_slug: str):
+def test_get_scorekeeper_details_by_slug(scorekeeper_slug: str):
     """Test /v2.0/scorekeepers/details/slug/{scorekeeper_slug} route."""
     response = client.get(
         f"/v{API_VERSION}/scorekeepers/details/slug/{scorekeeper_slug}"
@@ -101,7 +144,19 @@ def test_scorekeepers_details_slug(scorekeeper_slug: str):
     assert "appearances" in scorekeeper
 
 
-def test_scorekeepers_random():
+@pytest.mark.parametrize("scorekeeper_slug", ["-abcdef"])
+def test_get_scorekeeper_details_by_slug_not_found(scorekeeper_slug: str):
+    """Test /v2.0/scorekeepers/details/slug/{scorekeeper_slug} route."""
+    response = client.get(
+        f"/v{API_VERSION}/scorekeepers/details/slug/{scorekeeper_slug}"
+    )
+    scorekeeper = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in scorekeeper
+
+
+def test_get_random_scorekeeper():
     """Test /v2.0/scorekeepers/random route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/random")
     scorekeeper = response.json()
@@ -113,20 +168,7 @@ def test_scorekeepers_random():
     assert "slug" in scorekeeper
 
 
-def test_scorekeepers_random_details():
-    """Test /v2.0/scorekeepers/details/random route."""
-    response = client.get(f"/v{API_VERSION}/scorekeepers/details/random")
-    scorekeeper = response.json()
-
-    assert response.status_code == 200
-    assert "id" in scorekeeper
-    assert "name" in scorekeeper
-    assert "pronouns" in scorekeeper
-    assert "slug" in scorekeeper
-    assert "appearances" in scorekeeper
-
-
-def test_scorekeepers_random_id():
+def test_get_random_scorekeeper_id():
     """Test /v2.0/scorekeepers/random/id route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/random/id")
     _id = response.json()
@@ -136,7 +178,7 @@ def test_scorekeepers_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_scorekeepers_random_slug():
+def test_get_random_scorekeepers_slug():
     """Test /v2.0/scorekeepers/random/slug route."""
     response = client.get(f"/v{API_VERSION}/scorekeepers/random/slug")
     _slug = response.json()

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_shows():
+def test_get_shows():
     """Test /v2.0/shows route."""
     response = client.get(f"/v{API_VERSION}/shows")
     shows = response.json()
@@ -28,8 +28,28 @@ def test_shows():
     assert "show_url" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("inclusive", [True, False])
+def test_get_shows_best_ofs(inclusive: bool):
+    """Test /v2.0/shows/best-ofs route."""
+    response = client.get(
+        f"/v{API_VERSION}/shows/best-ofs", params={"inclusive": inclusive}
+    )
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
 @pytest.mark.parametrize("show_id", [1083])
-def test_shows_id(show_id: int):
+def test_get_show_by_id(show_id: int):
     """Test /v2.0/shows/id/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/id/{show_id}")
     show = response.json()
@@ -45,25 +65,18 @@ def test_shows_id(show_id: int):
     assert "original_show_date" in show
 
 
-def test_shows_best_ofs():
-    """Test /v2.0/shows/best-ofs route."""
-    response = client.get(f"/v{API_VERSION}/shows/best-ofs")
-    shows = response.json()
+@pytest.mark.parametrize("show_id", [0])
+def test_get_show_by_id_not_found(show_id: int):
+    """Test /v2.0/shows/id/{show_id} route."""
+    response = client.get(f"/v{API_VERSION}/shows/id/{show_id}")
+    show = response.json()
 
-    assert response.status_code == 200
-    assert "shows" in shows
-    assert "id" in shows["shows"][0]
-    assert "date" in shows["shows"][0]
-    assert "best_of" in shows["shows"][0]
-    assert shows["shows"][0]["best_of"] is True
-    assert "repeat_show" in shows["shows"][0]
-    assert "show_url" in shows["shows"][0]
-    assert "original_show_id" in shows["shows"][0]
-    assert "original_show_date" in shows["shows"][0]
+    assert response.status_code == 404
+    assert "detail" in show
 
 
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
-def test_shows_date_iso_show_date(show_date: str):
+def test_get_show_by_date_string(show_date: str):
     """Test /v2.0/shows/date/iso/{show_id} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/iso/{show_date}")
     show = response.json()
@@ -79,8 +92,18 @@ def test_shows_date_iso_show_date(show_date: str):
     assert "original_show_date" in show
 
 
+@pytest.mark.parametrize("show_date", ["1970-01-01"])
+def test_get_show_by_date_string_not_found(show_date: str):
+    """Test /v2.0/shows/date/iso/{show_id} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/iso/{show_date}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
 @pytest.mark.parametrize("year", [2006])
-def test_shows_date_year(year: int):
+def test_get_shows_by_year(year: int):
     """Test /v2.0/shows/date/{year} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}")
     shows = response.json()
@@ -98,8 +121,105 @@ def test_shows_date_year(year: int):
     assert "original_show_date" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_by_year_not_found(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_by_year_best_ofs(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/best-ofs")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_by_year_best_ofs_not_found(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_by_year_repeat_best_ofs(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/repeat-best-ofs")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_by_year_repeat_best_ofs_not_found(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/repeat-best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_by_year_repeats(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/repeats")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_by_year_repeats_not_found(year: int):
+    """Test /v2.0/shows/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/repeats")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("year, month", [(2006, 6)])
-def test_shows_date_year_month(year: int, month: int):
+def test_get_shows_by_year_month(year: int, month: int):
     """Test /v2.0/shows/date/{year}/{month} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}")
     shows = response.json()
@@ -117,8 +237,18 @@ def test_shows_date_year_month(year: int, month: int):
     assert "original_show_date" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("year, month", [(9999, 1)])
+def test_get_shows_by_year_month_not_found(year: int, month: int):
+    """Test /v2.0/shows/date/{year}/{month} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("month, day", [(10, 27)])
-def test_shows_date_month_day(month: int, day: int):
+def test_get_shows_by_month_day(month: int, day: int):
     """Test /v2.0/shows/date/month-day/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/month-day/{month}/{day}")
     shows = response.json()
@@ -136,8 +266,18 @@ def test_shows_date_month_day(month: int, day: int):
     assert "original_show_date" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("month, day", [(2, 30)])
+def test_get_shows_by_month_day_not_found(month: int, day: int):
+    """Test /v2.0/shows/date/month-day/{month}/{day} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/month-day/{month}/{day}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
-def test_shows_date_year_month_day(year: int, month: int, day: int):
+def test_get_show_by_date(year: int, month: int, day: int):
     """Test /v2.0/shows/date/{year}/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}/{day}")
     show = response.json()
@@ -154,7 +294,17 @@ def test_shows_date_year_month_day(year: int, month: int, day: int):
     assert "original_show_date" in show
 
 
-def test_show_dates():
+@pytest.mark.parametrize("year, month, day", [(1998, 2, 30)])
+def test_get_show_by_date_not_found(year: int, month: int, day: int):
+    """Test /v2.0/shows/date/{year}/{month}/{day} route."""
+    response = client.get(f"/v{API_VERSION}/shows/date/{year}/{month}/{day}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
+def test_get_all_show_dates():
     """Test /v2.0/shows/dates route."""
     response = client.get(f"/v{API_VERSION}/shows/dates")
     dates = response.json()
@@ -164,7 +314,7 @@ def test_show_dates():
     assert dates["shows"]
 
 
-def test_shows_details():
+def test_get_shows_details():
     """Test /v2.0/shows/details route."""
     response = client.get(f"/v{API_VERSION}/shows/details")
     shows = response.json()
@@ -186,9 +336,68 @@ def test_shows_details():
     assert "guests" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("inclusive", [True, False])
+def test_get_shows_details_best_ofs(inclusive: bool):
+    """Test /v2.0/shows/details/best-ofs route."""
+    response = client.get(
+        f"/v{API_VERSION}/shows/details/best-ofs", params={"inclusive": inclusive}
+    )
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("show_id", [1083])
+def test_get_show_details_by_id(show_id: int):
+    """Test /v2.0/shows/details/id/{show_id} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/id/{show_id}")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert show["id"] == show_id
+    assert "date" in show
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+    assert "location" in show
+    assert "description" in show
+    assert "host" in show
+    assert "scorekeeper" in show
+    assert "panelists" in show
+    assert "guests" in show
+
+
+@pytest.mark.parametrize("show_id", [0])
+def test_get_show_details_by_id_not_found(show_id: int):
+    """Test /v2.0/shows/details/id/{show_id} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/id/{show_id}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
-def test_shows_details_date_iso_show_date(show_date: str):
-    """Test /v2.0/shows/details/date/iso/{show_id} route."""
+def test_get_show_details_by_date_string(show_date: str):
+    """Test /v2.0/shows/details/date/iso/{show_date} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/iso/{show_date}")
     show = response.json()
 
@@ -209,8 +418,18 @@ def test_shows_details_date_iso_show_date(show_date: str):
     assert "guests" in show
 
 
+@pytest.mark.parametrize("show_date", ["1970-01-01"])
+def test_get_show_details_by_date_string_not_found(show_date: str):
+    """Test /v2.0/shows/details/date/iso/{show_date} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/iso/{show_date}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
 @pytest.mark.parametrize("year", [2006])
-def test_shows_details_date_year(year: int):
+def test_get_shows_details_by_year(year: int):
     """Test /v2.0/shows/details/date/{year} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}")
     shows = response.json()
@@ -234,8 +453,123 @@ def test_shows_details_date_year(year: int):
     assert "guests" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_details_by_year_not_found(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_details_by_year_best_ofs(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/best-ofs")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_details_by_year_best_ofs_not_found(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_details_by_year_repeat_best_ofs(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/repeat-best-ofs")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_details_by_year_repeat_best_ofs_not_found(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/repeat-best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
+@pytest.mark.parametrize("year", [2006])
+def test_get_shows_details_by_year_repeats(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/repeats")
+    shows = response.json()
+    formatted_year = f"{year:04}"
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert shows["shows"][0]["date"].startswith(formatted_year)
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_shows_details_by_year_repeats_not_found(year: int):
+    """Test /v2.0/shows/details/date/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/repeats")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("year, month", [(2006, 6)])
-def test_shows_details_date_year_month(year: int, month: int):
+def test_get_shows_details_by_year_month(year: int, month: int):
     """Test /v2.0/shows/details/date/{year}/{month} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}")
     shows = response.json()
@@ -259,8 +593,18 @@ def test_shows_details_date_year_month(year: int, month: int):
     assert "guests" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("year, month", [(9999, 1)])
+def test_get_shows_details_by_year_month_not_found(year: int, month: int):
+    """Test /v2.0/shows/details/date/{year}/{month} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("month, day", [(10, 27)])
-def test_shows_details_date_month_day(month: int, day: int):
+def test_get_shows_details_by_month_day(month: int, day: int):
     """Test /v2.0/shows/details/date/month-day/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/month-day/{month}/{day}")
     shows = response.json()
@@ -284,8 +628,18 @@ def test_shows_details_date_month_day(month: int, day: int):
     assert "guests" in shows["shows"][0]
 
 
+@pytest.mark.parametrize("month, day", [(2, 30)])
+def test_get_shows_details_by_month_day_not_found(month: int, day: int):
+    """Test /v2.0/shows/details/date/month-day/{month}/{day} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/month-day/{month}/{day}")
+    shows = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in shows
+
+
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
-def test_shows_details_date_year_month_day(year: int, month: int, day: int):
+def test_get_shows_details_by_date(year: int, month: int, day: int):
     """Test /v2.0/shows/details/date/{year}/{month}/{day} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}/{day}")
     show = response.json()
@@ -308,122 +662,17 @@ def test_shows_details_date_year_month_day(year: int, month: int, day: int):
     assert "guests" in show
 
 
-@pytest.mark.parametrize("show_id", [1083])
-def test_shows_details_id(show_id: int):
-    """Test /v2.0/shows/details/id/{show_id} route."""
-    response = client.get(f"/v{API_VERSION}/shows/details/id/{show_id}")
+@pytest.mark.parametrize("year, month, day", [(1998, 2, 30)])
+def test_get_shows_details_by_date_not_found(year: int, month: int, day: int):
+    """Test /v2.0/shows/details/date/{year}/{month}/{day} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/date/{year}/{month}/{day}")
     show = response.json()
 
-    assert response.status_code == 200
-    assert "id" in show
-    assert show["id"] == show_id
-    assert "date" in show
-    assert "best_of" in show
-    assert "repeat_show" in show
-    assert "show_url" in show
-    assert "original_show_id" in show
-    assert "original_show_date" in show
-    assert "location" in show
-    assert "description" in show
-    assert "host" in show
-    assert "scorekeeper" in show
-    assert "panelists" in show
-    assert "guests" in show
+    assert response.status_code == 404
+    assert "detail" in show
 
 
-def test_shows_details_recent():
-    """Test /v2.0/shows/details/recent route."""
-    response = client.get(f"/v{API_VERSION}/shows/details/recent")
-    shows = response.json()
-
-    assert response.status_code == 200
-    assert "shows" in shows
-    assert "id" in shows["shows"][0]
-    assert "date" in shows["shows"][0]
-    assert "best_of" in shows["shows"][0]
-    assert "repeat_show" in shows["shows"][0]
-    assert "show_url" in shows["shows"][0]
-    assert "original_show_id" in shows["shows"][0]
-    assert "original_show_date" in shows["shows"][0]
-    assert "location" in shows["shows"][0]
-    assert "description" in shows["shows"][0]
-    assert "host" in shows["shows"][0]
-    assert "scorekeeper" in shows["shows"][0]
-    assert "panelists" in shows["shows"][0]
-    assert "guests" in shows["shows"][0]
-
-
-def test_shows_recent():
-    """Test /v2.0/shows/recent route."""
-    response = client.get(f"/v{API_VERSION}/shows/recent")
-    shows = response.json()
-
-    assert response.status_code == 200
-    assert "shows" in shows
-    assert "id" in shows["shows"][0]
-    assert "date" in shows["shows"][0]
-    assert "best_of" in shows["shows"][0]
-    assert "repeat_show" in shows["shows"][0]
-    assert "show_url" in shows["shows"][0]
-    assert "original_show_id" in shows["shows"][0]
-    assert "original_show_date" in shows["shows"][0]
-
-
-def test_shows_repeat_best_ofs():
-    """Test /v2.0/shows/repeat-best-ofs route."""
-    response = client.get(f"/v{API_VERSION}/shows/repeat-best-ofs")
-    shows = response.json()
-
-    assert response.status_code == 200
-    assert "shows" in shows
-    assert "id" in shows["shows"][0]
-    assert "date" in shows["shows"][0]
-    assert "best_of" in shows["shows"][0]
-    assert shows["shows"][0]["best_of"] is True
-    assert "repeat_show" in shows["shows"][0]
-    assert shows["shows"][0]["repeat_show"] is True
-    assert "show_url" in shows["shows"][0]
-    assert "original_show_id" in shows["shows"][0]
-    assert isinstance(shows["shows"][0]["original_show_id"], int)
-    assert "original_show_date" in shows["shows"][0]
-    assert isinstance(shows["shows"][0]["original_show_date"], str)
-
-
-def test_shows_repeats():
-    """Test /v2.0/shows/repeats route."""
-    response = client.get(f"/v{API_VERSION}/shows/repeats")
-    shows = response.json()
-
-    assert response.status_code == 200
-    assert "shows" in shows
-    assert "id" in shows["shows"][0]
-    assert "date" in shows["shows"][0]
-    assert "best_of" in shows["shows"][0]
-    assert "repeat_show" in shows["shows"][0]
-    assert shows["shows"][0]["repeat_show"] is True
-    assert "show_url" in shows["shows"][0]
-    assert "original_show_id" in shows["shows"][0]
-    assert isinstance(shows["shows"][0]["original_show_id"], int)
-    assert "original_show_date" in shows["shows"][0]
-    assert isinstance(shows["shows"][0]["original_show_date"], str)
-
-
-def test_shows_random():
-    """Test /v2.0/shows/random route."""
-    response = client.get(f"/v{API_VERSION}/shows/random")
-    show = response.json()
-
-    assert response.status_code == 200
-    assert "id" in show
-    assert "date" in show
-    assert "best_of" in show
-    assert "repeat_show" in show
-    assert "show_url" in show
-    assert "original_show_id" in show
-    assert "original_show_date" in show
-
-
-def test_shows_random_details():
+def test_get_random_show_details():
     """Test /v2.0/shows/details/random route."""
     response = client.get(f"/v{API_VERSION}/shows/details/random")
     show = response.json()
@@ -445,24 +694,7 @@ def test_shows_random_details():
 
 
 @pytest.mark.parametrize("year", [1998, 2020])
-def test_shows_random_show_by_year(year: int):
-    """Test /v2.0/shows/random/year/{year} route."""
-    response = client.get(f"/v{API_VERSION}/shows/random/year/{year}")
-    show = response.json()
-
-    assert response.status_code == 200
-    assert "id" in show
-    assert "date" in show
-    assert str(year) in show["date"]
-    assert "best_of" in show
-    assert "repeat_show" in show
-    assert "show_url" in show
-    assert "original_show_id" in show
-    assert "original_show_date" in show
-
-
-@pytest.mark.parametrize("year", [1998, 2020])
-def test_shows_random_show_by_year_details(year: int):
+def test_get_random_show_by_year_details(year: int):
     """Test /v2.0/shows/details/random/year/{year} route."""
     response = client.get(f"/v{API_VERSION}/shows/details/random/year/{year}")
     show = response.json()
@@ -484,7 +716,118 @@ def test_shows_random_show_by_year_details(year: int):
     assert "guests" in show
 
 
-def test_shows_random_id():
+@pytest.mark.parametrize("year", [9999])
+def test_get_random_show_by_year_details_not_found(year: int):
+    """Test /v2.0/shows/details/random/year/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/random/year/{year}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
+def test_get_shows_recent_details():
+    """Test /v2.0/shows/details/recent route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/recent")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+def test_get_shows_details_repeat_best_ofs():
+    """Test /v2.0/shows/details/repeat-best-ofs route."""
+    response = client.get(f"/v{API_VERSION}/shows/details/repeat-best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+@pytest.mark.parametrize("inclusive", [True, False])
+def test_get_shows_details_repeats(inclusive: bool):
+    """Test /v2.0/shows/repeats route."""
+    response = client.get(
+        f"/v{API_VERSION}/shows/details/repeats", params={"inclusive": inclusive}
+    )
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)
+    assert "location" in shows["shows"][0]
+    assert "description" in shows["shows"][0]
+    assert "host" in shows["shows"][0]
+    assert "scorekeeper" in shows["shows"][0]
+    assert "panelists" in shows["shows"][0]
+    assert "guests" in shows["shows"][0]
+
+
+def test_get_random_show():
+    """Test /v2.0/shows/random route."""
+    response = client.get(f"/v{API_VERSION}/shows/random")
+    show = response.json()
+
+    assert response.status_code == 200
+    assert "id" in show
+    assert "date" in show
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+
+
+def test_get_random_show_date():
+    """Test /v2.0/shows/random/date route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/date")
+    _date = response.json()
+
+    assert response.status_code == 200
+    assert "date" in _date
+    assert isinstance(_date["date"], str)
+
+
+def test_get_random_show_id():
     """Test /v2.0/shows/random/id route."""
     response = client.get(f"/v{API_VERSION}/shows/random/id")
     _id = response.json()
@@ -494,11 +837,86 @@ def test_shows_random_id():
     assert isinstance(_id["id"], int)
 
 
-def test_shows_random_date():
-    """Test /v2.0/shows/random/date route."""
-    response = client.get(f"/v{API_VERSION}/shows/random/date")
-    _date = response.json()
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_get_random_show_by_year(year: int):
+    """Test /v2.0/shows/random/year/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/year/{year}")
+    show = response.json()
 
     assert response.status_code == 200
-    assert "date" in _date
-    assert isinstance(_date["date"], str)
+    assert "id" in show
+    assert "date" in show
+    assert str(year) in show["date"]
+    assert "best_of" in show
+    assert "repeat_show" in show
+    assert "show_url" in show
+    assert "original_show_id" in show
+    assert "original_show_date" in show
+
+
+@pytest.mark.parametrize("year", [9999])
+def test_get_random_show_by_year_not_found(year: int):
+    """Test /v2.0/shows/random/year/{year} route."""
+    response = client.get(f"/v{API_VERSION}/shows/random/year/{year}")
+    show = response.json()
+
+    assert response.status_code == 404
+    assert "detail" in show
+
+
+def test_get_shows_recent():
+    """Test /v2.0/shows/recent route."""
+    response = client.get(f"/v{API_VERSION}/shows/recent")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert "original_show_date" in shows["shows"][0]
+
+
+def test_get_shows_repeat_best_ofs():
+    """Test /v2.0/shows/repeat-best-ofs route."""
+    response = client.get(f"/v{API_VERSION}/shows/repeat-best-ofs")
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert shows["shows"][0]["best_of"] is True
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)
+
+
+@pytest.mark.parametrize("inclusive", [True, False])
+def test_get_shows_repeats(inclusive: bool):
+    """Test /v2.0/shows/repeats route."""
+    response = client.get(
+        f"/v{API_VERSION}/shows/repeats", params={"inclusive": inclusive}
+    )
+    shows = response.json()
+
+    assert response.status_code == 200
+    assert "shows" in shows
+    assert "id" in shows["shows"][0]
+    assert "date" in shows["shows"][0]
+    assert "best_of" in shows["shows"][0]
+    assert "repeat_show" in shows["shows"][0]
+    assert shows["shows"][0]["repeat_show"] is True
+    assert "show_url" in shows["shows"][0]
+    assert "original_show_id" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_id"], int)
+    assert "original_show_date" in shows["shows"][0]
+    assert isinstance(shows["shows"][0]["original_show_date"], str)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,7 +14,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_version():
+def test_get_version():
     """Test /version route."""
     response = client.get(f"/v{API_VERSION}/version")
     version = response.json()


### PR DESCRIPTION
## Application Changes

- Replace `raise HTTPException` with using `return JSONResponse` and use a new `MessageDetails` response model to validate the response. The returned message uses the same format, but this change adds a specific response model to the OpenAPI specification.
- Updates to the Shows API endpoints
  - Add optional `inclusive` boolean query paramter to `/best-ofs` and `/details/best-ofs` that will determine whether to include Repeat Best Of shows along with non-repeat Best Of shows (default: `true`)
  - Add optional `inclusive` boolean query paramter to `/repeats` and `/details/repeats` that will determine whether to include Repeat Best Of shows along with non-Best Of repeat shows (default: `true`)
  - Fix response model issue with `/details/best-ofs` and `/details/repeats`
  - Add missing `include_decimal_scores` named parameter and values to show retrieval method calls for `/details/best-ofs`, `/details/repeat-best-ofs` and `/details/repeats` endpoints
- Added the following Show endpoints:
  - `/date/{year}/best-ofs`
  - `/date/{year}/repeat-best-ofs`
  - `/date/{year}/repeats`
  - `/details/date/{year}/best-ofs`
  - `/details/date/{year}/repeat-best-ofs`
  - `/details/date/{year}/repeats`
- Renamed endpoint function names in order to have a more consistent naming convention

## Development Changes

- Add missing tests for `/details/best-ofs`, `/details/repeat-best-ofs` and `/details/repeats`
- Rename test function names to use a `test_` prefix and the name of the API endpoint function name
- Add tests cases to check if endpoints are returning `404` when there are no corresponding values