### PR TITLE
Upgrade requests, ruff, pytest and pytest-cov dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 2.18.1
+
+### Component Changes
+
+- Upgrade requests from 2.32.3 to 2.32.4
+
+### Development Changes
+
+- Upgrade ruff from 0.9.3 to 0.11.9
+- Upgrade pytest from 8.3.4 to 8.3.5
+- Upgrade pytest-cov from 6.0.0 to 6.1.1
+
 ## 2.18.0
 
 ### Application Changes

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.18.0"
+APP_VERSION = "2.18.1"
 
 
 def load_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-ruff==0.9.3
-pytest==8.3.4
-pytest-cov==6.0.0
+ruff==0.11.9
+pytest==8.3.5
+pytest-cov==6.1.1
 
 pydantic==2.11.4
 fastapi==0.115.12
@@ -10,6 +10,6 @@ httpx==0.28.1
 aiofiles==24.1.0
 jinja2==3.1.6
 email-validator==2.2.0
-requests==2.32.3
+requests==2.32.4
 
 wwdtm==2.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ httpx==0.28.1
 aiofiles==24.1.0
 jinja2==3.1.6
 email-validator==2.2.0
-requests==2.32.3
+requests==2.32.4
 
 wwdtm==2.18.2


### PR DESCRIPTION
## Component Changes

- Upgrade requests from 2.32.3 to 2.32.4

## Development Changes

- Upgrade ruff from 0.9.3 to 0.11.9
- Upgrade pytest from 8.3.4 to 8.3.5
- Upgrade pytest-cov from 6.0.0 to 6.1.1