### PR TITLE
Standardize on "Lightning Fill In The Blank" segment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 2.18.2
+
+### Application Changes
+
+- Standardized on the name "Lightning Fill In The Blank" for the segment, including:
+  - Replaced all references of "Lightning Round" in report titles with "Lightning Fill In The Blank Segment"
+  - Replaced "Fill-in-the-Blank" with "Fill In The Blank"
+  - This does not change the name of the functions, variables or keys returned
+
 ## 2.18.1
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.18.1"
+APP_VERSION = "2.18.2"
 
 
 def load_config(

--- a/app/models/panelists.py
+++ b/app/models/panelists.py
@@ -139,16 +139,17 @@ class ShowAppearance(BaseModel):
     best_of: bool = Field(title="Best Of Show")
     repeat_show: bool = Field(title="Repeat Show")
     lightning_round_start: int | None = Field(
-        default=None, title="Lightning Round Starting Score"
+        default=None, title="Lightning Fill In The Blank segment Starting Score"
     )
     lightning_round_start_decimal: Decimal | None = Field(
-        default=None, title="Lightning Round Starting Decimal Score"
+        default=None, title="Lightning Fill In The Blank segment Starting Decimal Score"
     )
     lightning_round_correct: int | None = Field(
-        default=None, title="Lightning Round Correct Answers"
+        default=None, title="Lightning Fill In The Blank segment Correct Answers"
     )
     lightning_round_correct_decimal: Decimal | None = Field(
-        default=None, title="Lightning Round Correct Answers (Decimal)"
+        default=None,
+        title="Lightning Fill In The Blank segment Correct Answers (Decimal)",
     )
     score: int | None = Field(default=None, title="Total Score")
     score_decimal: Decimal | None = Field(default=None, title="Total Decimal Score")

--- a/app/models/shows.py
+++ b/app/models/shows.py
@@ -89,16 +89,16 @@ class ShowPanelist(BaseModel):
     name: str = Field(title="Panelist Name")
     slug: str | None = Field(default=None, title="Panelist Slug String")
     lightning_round_start: int | None = Field(
-        default=None, title="Lightning Fill-in-the-Blank Starting Score"
+        default=None, title="Lightning Fill In The Blank Starting Score"
     )
     lightning_round_start_decimal: Decimal | None = Field(
-        default=None, title="Lightning Fill-in-the-Blank Starting Decimal Score"
+        default=None, title="Lightning Fill In The Blank Starting Decimal Score"
     )
     lightning_round_correct: int | None = Field(
-        default=None, title="Lightning Fill-in-the-Blank Correct Answers"
+        default=None, title="Lightning Fill In The Blank Correct Answers"
     )
     lightning_round_correct_decimal: Decimal | None = Field(
-        default=None, title="Lightning Fill-in-the-Blank Correct Answers (Decimal)"
+        default=None, title="Lightning Fill In The Blank Correct Answers (Decimal)"
     )
     score: int | None = Field(default=None, title="Panelist Score")
     score_decimal: Decimal | None = Field(default=None, title="Panelist Decimal Score")


### PR DESCRIPTION
## Application Changes

- Standardized on the name "Lightning Fill In The Blank" for the segment, including:
  - Replaced all references of "Lightning Round" in report titles with "Lightning Fill In The Blank Segment"
  - Replaced "Fill-in-the-Blank" with "Fill In The Blank"
  - This does not change the name of the functions, variables or keys returned