### PR TITLE
Decimal scores required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## 2.22.0-alpha (Pre-Release)
+
+### Application Changes
+
+- The Stats API now requires panelist decimal score columns in the Wait Wait Stats Database
+  - Removed the `settings.use_decimal_scores` configuration key references and logic
+- Added `database` field to the `Version` model and to the output of the `/version` endpoint
+
+### Component Changes
+
+- Upgraded wwdtm from 2.23.1 to 3.0.0-alpha
+
+
 ## 2.21.1-post0
 
 ### Development Changes
@@ -10,7 +23,7 @@
 
 ### Component Changes
 
-- Upgrade requests from 2.32.5 to 2.33.1
+- Upgraded requests from 2.32.5 to 2.33.1
 
 ## 2.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@
 - The Stats API now requires panelist decimal score columns in the Wait Wait Stats Database
   - Removed the `settings.use_decimal_scores` configuration key references and logic
 - Added `database` field to the `Version` model and to the output of the `/version` endpoint
+- Replaced Google Fonts with Bunny Fonts as the web font provider for the required IBM Plex fonts
 
 ### Component Changes
 
-- Upgraded wwdtm from 2.23.1 to 3.0.0-alpha
+- Upgraded FastAPI from 0.128.0 to 0.136.3
+- Upgraded Pydantic from 2.12.5 to 2.13.4
+- Upgraded uvicorn from 0.40.0 to 0.48.0
+- Upgraded wwdtm from 2.23.1 to 3.0.0
 
+### Development Changes
+
+- Added pydoclint 0.8.4 for docstring linting
 
 ## 2.21.1-post0
 

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 API_VERSION = "2.0"
-APP_VERSION = "2.21.1"
+APP_VERSION = "2.22.0-alpha"
 
 
 def load_config(
@@ -34,9 +34,6 @@ def load_config(
         config_dict = json.load(config_file)
 
     settings_config = config_dict.get("settings", None)
-    settings_config["use_decimal_scores"] = bool(
-        settings_config.get("use_decimal_scores", False)
-    )
 
     if "database" in config_dict:
         database_config = config_dict["database"]

--- a/app/models/version.py
+++ b/app/models/version.py
@@ -13,4 +13,5 @@ class Version(BaseModel):
 
     api: str = Field(title="Wait Wait Stats API Version")
     app: str = Field(title="Application Version")
+    database: str | None = Field(title="Wait Wait Stats Database Version")
     wwdtm: str = Field(title="wwdtm Version")

--- a/app/routers/guests.py
+++ b/app/routers/guests.py
@@ -46,6 +46,7 @@ async def get_guests():
     try:
         guest = Guest(database_connection=_database_connection)
         guests = guest.retrieve_all()
+
         if guests:
             return {"guests": guests}
 
@@ -82,6 +83,7 @@ async def get_guest_by_id(
     try:
         guest = Guest(database_connection=_database_connection)
         guest_info = guest.retrieve_by_id(guest_id)
+
         if guest_info:
             return guest_info
 
@@ -123,6 +125,7 @@ async def get_guest_by_slug(
     try:
         guest = Guest(database_connection=_database_connection)
         guest_info = guest.retrieve_by_slug(guest_slug.strip())
+
         if guest_info:
             return guest_info
 
@@ -166,6 +169,7 @@ async def get_guests_details():
     try:
         guest = Guest(database_connection=_database_connection)
         guests = guest.retrieve_all_details()
+
         if guests:
             return {"guests": guests}
 
@@ -204,6 +208,7 @@ async def get_guest_details_by_id(
     try:
         guest = Guest(database_connection=_database_connection)
         guest_details = guest.retrieve_details_by_id(guest_id)
+
         if guest_details:
             return guest_details
 
@@ -245,6 +250,7 @@ async def get_random_guest_details():
     try:
         guest = Guest(database_connection=_database_connection)
         guest_details = guest.retrieve_random_details()
+
         if guest_details:
             return guest_details
 
@@ -288,6 +294,7 @@ async def get_guest_details_by_slug(
     try:
         guest = Guest(database_connection=_database_connection)
         guest_details = guest.retrieve_details_by_slug(guest_slug.strip())
+
         if guest_details:
             return guest_details
 
@@ -329,6 +336,7 @@ async def get_random_guest():
     try:
         guest = Guest(database_connection=_database_connection)
         guest_info = guest.retrieve_random()
+
         if guest_info:
             return guest_info
 
@@ -368,6 +376,7 @@ async def get_random_guest_id():
     try:
         guest = Guest(database_connection=_database_connection)
         guest_id = guest.retrieve_random_id()
+
         if guest_id:
             return {"id": guest_id}
 
@@ -407,6 +416,7 @@ async def get_random_guest_slug():
     try:
         guest = Guest(database_connection=_database_connection)
         guest_slug = guest.retrieve_random_slug()
+
         if guest_slug:
             return {"slug": guest_slug}
 

--- a/app/routers/hosts.py
+++ b/app/routers/hosts.py
@@ -46,6 +46,7 @@ async def get_hosts():
     try:
         host = Host(database_connection=_database_connection)
         hosts = host.retrieve_all()
+
         if hosts:
             return {"hosts": hosts}
 
@@ -82,6 +83,7 @@ async def get_host_by_id(
     try:
         host = Host(database_connection=_database_connection)
         host_info = host.retrieve_by_id(host_id)
+
         if host_info:
             return host_info
 
@@ -123,6 +125,7 @@ async def get_host_by_slug(
     try:
         host = Host(database_connection=_database_connection)
         host_info = host.retrieve_by_slug(host_slug)
+
         if host_info:
             return host_info
 
@@ -166,6 +169,7 @@ async def get_hosts_details():
     try:
         host = Host(database_connection=_database_connection)
         hosts = host.retrieve_all_details()
+
         if hosts:
             return {"hosts": hosts}
 
@@ -204,6 +208,7 @@ async def get_host_details_by_id(
     try:
         host = Host(database_connection=_database_connection)
         host_details = host.retrieve_details_by_id(host_id)
+
         if host_details:
             return host_details
 
@@ -245,6 +250,7 @@ async def get_random_host_details():
     try:
         host = Host(database_connection=_database_connection)
         host_details = host.retrieve_random_details()
+
         if host_details:
             return host_details
 
@@ -288,6 +294,7 @@ async def get_host_details_by_slug(
     try:
         host = Host(database_connection=_database_connection)
         host_details = host.retrieve_details_by_slug(host_slug)
+
         if host_details:
             return host_details
 
@@ -329,6 +336,7 @@ async def get_random_host():
     try:
         host = Host(database_connection=_database_connection)
         host_info = host.retrieve_random()
+
         if host_info:
             return host_info
 
@@ -368,6 +376,7 @@ async def get_random_host_id():
     try:
         host = Host(database_connection=_database_connection)
         host_id = host.retrieve_random_id()
+
         if host_id:
             return {"id": host_id}
 
@@ -407,6 +416,7 @@ async def get_random_host_slug():
     try:
         host = Host(database_connection=_database_connection)
         host_slug = host.retrieve_random_slug()
+
         if host_slug:
             return {"slug": host_slug}
 

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -53,6 +53,7 @@ async def get_locations():
     try:
         location = Location(database_connection=_database_connection)
         locations = location.retrieve_all(sort_by_venue=True)
+
         if locations:
             return {"locations": locations}
 
@@ -91,6 +92,7 @@ async def get_location_by_id(
     try:
         location = Location(database_connection=_database_connection)
         location_info = location.retrieve_by_id(location_id)
+
         if location_info:
             return location_info
 
@@ -133,6 +135,7 @@ async def get_location_by_slug(
     try:
         location = Location(database_connection=_database_connection)
         location_info = location.retrieve_by_slug(location_slug.strip())
+
         if location_info:
             return location_info
 
@@ -179,6 +182,7 @@ async def get_locations_details():
     try:
         location = Location(database_connection=_database_connection)
         locations = location.retrieve_all_details(sort_by_venue=True)
+
         if locations:
             return {"locations": locations}
 
@@ -220,6 +224,7 @@ async def get_location_details_by_id(
     try:
         location = Location(database_connection=_database_connection)
         location_recordings = location.retrieve_details_by_id(location_id)
+
         if location_recordings:
             return location_recordings
 
@@ -262,6 +267,7 @@ async def get_random_location_details():
     try:
         location = Location(database_connection=_database_connection)
         location_details = location.retrieve_random_details()
+
         if location_details:
             return location_details
 
@@ -307,6 +313,7 @@ async def get_location_details_by_slug(
     try:
         location = Location(database_connection=_database_connection)
         location_details = location.retrieve_details_by_slug(location_slug.strip())
+
         if location_details:
             return location_details
 
@@ -352,6 +359,7 @@ async def get_postal_abbreviations() -> list[str]:
     try:
         location = Location(database_connection=_database_connection)
         abbreviations = location.retrieve_postal_abbreviations()
+
         if abbreviations:
             return list(abbreviations.keys())
 
@@ -391,6 +399,7 @@ async def get_postal_abbreviations_details() -> list[dict[str, str]]:
     try:
         location = Location(database_connection=_database_connection)
         abbreviations = location.retrieve_postal_abbreviations_list()
+
         if abbreviations:
             return {"postal_abbreviations": abbreviations}
 
@@ -434,6 +443,7 @@ async def get_postal_abbreviation_details(
         info = location.retrieve_postal_details_by_abbreviation(
             abbreviation=abbreviation
         )
+
         if info:
             return info
 
@@ -476,6 +486,7 @@ async def get_random_location():
     try:
         location = Location(database_connection=_database_connection)
         location_info = location.retrieve_random()
+
         if location_info:
             return location_info
 
@@ -516,6 +527,7 @@ async def get_random_location_id():
     try:
         location = Location(database_connection=_database_connection)
         location_id = location.retrieve_random_id()
+
         if location_id:
             return {"id": location_id}
 
@@ -556,6 +568,7 @@ async def get_random_location_slug():
     try:
         location = Location(database_connection=_database_connection)
         location_slug = location.retrieve_random_slug()
+
         if location_slug:
             return {"slug": location_slug}
 

--- a/app/routers/panelists.py
+++ b/app/routers/panelists.py
@@ -53,6 +53,7 @@ async def get_panelists():
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelists = panelist.retrieve_all()
+
         if panelists:
             return {"panelists": panelists}
 
@@ -91,6 +92,7 @@ async def get_panelist_by_id(
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_info = panelist.retrieve_by_id(panelist_id)
+
         if panelist_info:
             return panelist_info
 
@@ -133,6 +135,7 @@ async def get_panelist_by_slug(
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_info = panelist.retrieve_by_slug(panelist_slug.strip())
+
         if panelist_info:
             return panelist_info
 
@@ -178,9 +181,8 @@ async def get_panelists_details():
     """
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelists = panelist.retrieve_all_details(
-            use_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        panelists = panelist.retrieve_all_details()
+
         if panelists:
             return {"panelists": panelists}
 
@@ -221,9 +223,8 @@ async def get_panelist_details_by_id(
     """
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_details_by_id(
-            panelist_id, use_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        panelist_details = panelist.retrieve_details_by_id(panelist_id)
+
         if panelist_details:
             return panelist_details
 
@@ -266,9 +267,8 @@ async def get_random_panelist_details():
     """
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_random_details(
-            use_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        panelist_details = panelist.retrieve_random_details()
+
         if panelist_details:
             return panelist_details
 
@@ -313,10 +313,8 @@ async def get_panelist_details_by_slug(
     """
     try:
         panelist = Panelist(database_connection=_database_connection)
-        panelist_details = panelist.retrieve_details_by_slug(
-            panelist_slug.strip(),
-            use_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        panelist_details = panelist.retrieve_details_by_slug(panelist_slug.strip())
+
         if panelist_details:
             return panelist_details
 
@@ -361,16 +359,13 @@ async def get_panelist_scores_by_id(
     Returned data: One array with show dates and one array with scores.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_list_by_id(
-                panelist_id,
-            )
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_list_by_id(panelist_id)
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+        scores = panelist_scores.retrieve_scores_list_by_id(
+            panelist_id,
+        )
+
         if scores:
             return scores
 
@@ -411,14 +406,11 @@ async def get_panelist_scores_by_slug(
     Returned data: One array with show dates and one array with scores.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug.strip())
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug.strip())
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+        scores = panelist_scores.retrieve_scores_list_by_slug(panelist_slug.strip())
+
         if scores:
             return scores
 
@@ -468,18 +460,11 @@ async def get_panelist_scores_grouped_ordered_pair_by_id(
     and one element with corresponding score count.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_id(
-                panelist_id
-            )
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_id(
-                panelist_id
-            )
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+        scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_id(panelist_id)
+
         if scores:
             return {"scores": scores}
 
@@ -526,18 +511,14 @@ async def get_panelist_scores_grouped_ordered_pair_by_slug(
     and one element with corresponding score count.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_slug(
-                panelist_slug.strip()
-            )
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_slug(
-                panelist_slug.strip()
-            )
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+
+        scores = panelist_scores.retrieve_scores_grouped_ordered_pair_by_slug(
+            panelist_slug.strip()
+        )
+
         if scores:
             return {"scores": scores}
 
@@ -584,14 +565,11 @@ async def get_panelist_scores_ordered_pair_by_id(
     date and one element with corresponding score.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_id(panelist_id)
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_id(panelist_id)
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+        scores = panelist_scores.retrieve_scores_ordered_pair_by_id(panelist_id)
+
         if scores:
             return {"scores": scores}
 
@@ -633,18 +611,13 @@ async def get_panelist_scores_ordered_pair_by_slug(
     date and one element with corresponding score.
     """
     try:
-        if _config["settings"]["use_decimal_scores"]:
-            panelist_scores = PanelistDecimalScores(
-                database_connection=_database_connection
-            )
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(
-                panelist_slug.strip()
-            )
-        else:
-            panelist_scores = PanelistScores(database_connection=_database_connection)
-            scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(
-                panelist_slug.strip()
-            )
+        panelist_scores = PanelistDecimalScores(
+            database_connection=_database_connection
+        )
+        scores = panelist_scores.retrieve_scores_ordered_pair_by_slug(
+            panelist_slug.strip()
+        )
+
         if scores:
             return {"scores": scores}
 
@@ -688,6 +661,7 @@ async def get_random_panelist():
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_info = panelist.retrieve_random()
+
         if panelist_info:
             return panelist_info
 
@@ -728,6 +702,7 @@ async def get_random_panelist_id():
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_id = panelist.retrieve_random_id()
+
         if panelist_id:
             return {"id": panelist_id}
 
@@ -768,6 +743,7 @@ async def get_random_panelist_slug():
     try:
         panelist = Panelist(database_connection=_database_connection)
         panelist_slug = panelist.retrieve_random_slug()
+
         if panelist_slug:
             return {"slug": panelist_slug}
 

--- a/app/routers/pronouns.py
+++ b/app/routers/pronouns.py
@@ -42,6 +42,7 @@ async def get_pronouns():
     try:
         _pronouns = Pronouns(database_connection=_database_connection)
         all_pronouns = _pronouns.retrieve_all()
+
         if all_pronouns:
             return {"pronouns": all_pronouns}
 
@@ -80,6 +81,7 @@ async def get_pronouns_by_id(
     try:
         _pronouns = Pronouns(database_connection=_database_connection)
         pronouns_info = _pronouns.retrieve_by_id(pronouns_id)
+
         if pronouns_info:
             return pronouns_info
 

--- a/app/routers/scorekeepers.py
+++ b/app/routers/scorekeepers.py
@@ -46,6 +46,7 @@ async def get_scorekeepers():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeepers = scorekeeper.retrieve_all()
+
         if scorekeepers:
             return {"scorekeepers": scorekeepers}
 
@@ -86,6 +87,7 @@ async def get_scorekeeper_by_id(
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_info = scorekeeper.retrieve_by_id(scorekeeper_id)
+
         if scorekeeper_info:
             return scorekeeper_info
 
@@ -132,6 +134,7 @@ async def get_scorekeeper_by_slug(
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_info = scorekeeper.retrieve_by_slug(scorekeeper_slug.strip())
+
         if scorekeeper_info:
             return scorekeeper_info
 
@@ -178,6 +181,7 @@ async def get_scorekeepers_details():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeepers = scorekeeper.retrieve_all_details()
+
         if scorekeepers:
             return {"scorekeepers": scorekeepers}
 
@@ -221,6 +225,7 @@ async def get_scorekeeper_details_by_id(
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_details = scorekeeper.retrieve_details_by_id(scorekeeper_id)
+
         if scorekeeper_details:
             return scorekeeper_details
 
@@ -266,6 +271,7 @@ async def get_random_scorekeeper_details():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_details = scorekeeper.retrieve_random_details()
+
         if scorekeeper_details:
             return scorekeeper_details
 
@@ -315,6 +321,7 @@ async def get_scorekeeper_details_by_slug(
         scorekeeper_details = scorekeeper.retrieve_details_by_slug(
             scorekeeper_slug.strip()
         )
+
         if scorekeeper_details:
             return scorekeeper_details
 
@@ -357,6 +364,7 @@ async def get_random_scorekeeper():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_info = scorekeeper.retrieve_random()
+
         if scorekeeper_info:
             return scorekeeper_info
 
@@ -397,6 +405,7 @@ async def get_random_scorekeeper_id():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_id = scorekeeper.retrieve_random_id()
+
         if scorekeeper_id:
             return {"id": scorekeeper_id}
 
@@ -437,6 +446,7 @@ async def get_random_scorekeeper_slug():
     try:
         scorekeeper = Scorekeeper(database_connection=_database_connection)
         scorekeeper_slug = scorekeeper.retrieve_random_slug()
+
         if scorekeeper_slug:
             return {"slug": scorekeeper_slug}
 

--- a/app/routers/shows.py
+++ b/app/routers/shows.py
@@ -49,6 +49,7 @@ async def get_shows():
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_all()
+
         if shows:
             return {"shows": shows}
 
@@ -88,6 +89,7 @@ async def get_shows_best_ofs(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_all_best_ofs(inclusive=inclusive)
+
         if show_info:
             return {"shows": show_info}
 
@@ -127,6 +129,7 @@ async def get_show_by_id(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_id(show_id)
+
         if show_info:
             return show_info
 
@@ -170,6 +173,7 @@ async def get_show_by_date_string(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_date_string(show_date.isoformat())
+
         if show_info:
             return show_info
 
@@ -215,6 +219,7 @@ async def get_shows_by_year(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_year(year)
+
         if shows:
             return {"shows": shows}
 
@@ -263,6 +268,7 @@ async def get_shows_by_year_best_ofs(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_best_ofs_by_year(year=year, inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -310,6 +316,7 @@ async def get_shows_by_year_repeat_best_ofs(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_repeat_best_ofs_by_year(year=year)
+
         if shows:
             return {"shows": shows}
 
@@ -360,6 +367,7 @@ async def get_shows_by_year_repeats(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_repeats_by_year(year=year, inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -408,6 +416,7 @@ async def get_shows_by_year_month(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_year_month(year, month)
+
         if shows:
             return {"shows": shows}
 
@@ -456,6 +465,7 @@ async def get_shows_by_month_day(
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_by_month_day(month, day)
+
         if shows:
             return {"shows": shows}
 
@@ -503,6 +513,7 @@ async def get_show_by_date(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_by_date(year, month, day)
+
         if show_info:
             return show_info
 
@@ -545,6 +556,7 @@ async def get_all_show_dates():
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_all_dates()
+
         if shows:
             return {"shows": shows}
 
@@ -582,9 +594,8 @@ async def get_shows_details():
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_all_details(
-            include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        shows = show.retrieve_all_details()
+
         if shows:
             return {"shows": shows}
 
@@ -623,10 +634,8 @@ async def get_shows_details_best_ofs(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_all_best_ofs_details(
-            inclusive=inclusive,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_all_best_ofs_details(inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -666,9 +675,8 @@ async def get_show_details_by_id(
     """
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_id(
-            show_id, include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        show_details = show.retrieve_details_by_id(show_id)
+
         if show_details:
             return show_details
 
@@ -712,10 +720,8 @@ async def get_show_details_by_date_string(
     """
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_date_string(
-            show_date.isoformat(),
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        show_details = show.retrieve_details_by_date_string(show_date.isoformat())
+
         if show_details:
             return show_details
 
@@ -761,9 +767,8 @@ async def get_shows_details_by_year(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_year(
-            year, include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        shows = show.retrieve_details_by_year(year)
+
         if shows:
             return {"shows": shows}
 
@@ -811,11 +816,8 @@ async def get_shows_details_by_year_best_ofs(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_best_ofs_details_by_year(
-            year=year,
-            inclusive=inclusive,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_best_ofs_details_by_year(year=year, inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -862,10 +864,8 @@ async def get_shows_details_by_year_repeat_best_ofs(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_repeat_best_ofs_details_by_year(
-            year=year,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_repeat_best_ofs_details_by_year(year=year)
+
         if shows:
             return {"shows": shows}
 
@@ -915,11 +915,8 @@ async def get_shows_details_by_year_repeats(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_repeats_details_by_year(
-            year=year,
-            inclusive=inclusive,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_repeats_details_by_year(year=year, inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -968,11 +965,8 @@ async def get_shows_details_by_year_month(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_year_month(
-            year,
-            month,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_details_by_year_month(year, month)
+
         if shows:
             return {"shows": shows}
 
@@ -1021,9 +1015,8 @@ async def get_shows_details_by_month_day(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_details_by_month_day(
-            month, day, include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        shows = show.retrieve_details_by_month_day(month, day)
+
         if shows:
             return {"shows": shows}
 
@@ -1075,12 +1068,8 @@ async def get_show_details_by_date(
     """
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_details_by_date(
-            year,
-            month,
-            day,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        show_details = show.retrieve_details_by_date(year, month, day)
+
         if show_details:
             return show_details
 
@@ -1124,9 +1113,8 @@ async def get_random_show_details():
     """
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_random_details(
-            include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        show_details = show.retrieve_random_details()
+
         if show_details:
             return show_details
 
@@ -1171,9 +1159,8 @@ async def get_random_show_by_year_details(
     """
     try:
         show = Show(database_connection=_database_connection)
-        show_details = show.retrieve_random_details_by_year(
-            year=year, include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        show_details = show.retrieve_random_details_by_year(year=year)
+
         if show_details:
             return show_details
 
@@ -1217,9 +1204,8 @@ async def get_shows_recent_details():
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_recent_details(
-            include_decimal_scores=_config["settings"]["use_decimal_scores"]
-        )
+        shows = show.retrieve_recent_details()
+
         if shows:
             return {"shows": shows}
 
@@ -1256,9 +1242,8 @@ async def get_shows_details_repeat_best_ofs():
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_all_repeat_best_ofs_details(
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_all_repeat_best_ofs_details()
+
         if shows:
             return {"shows": shows}
 
@@ -1293,7 +1278,6 @@ async def get_shows_details_repeats(
     inclusive: Annotated[
         bool, Query(title="Include Best Of shows with repeat shows")
     ] = True,
-    include_decimal_scores=_config["settings"]["use_decimal_scores"],
 ):
     """Retrieve all Repeat Shows.
 
@@ -1302,10 +1286,8 @@ async def get_shows_details_repeats(
     """
     try:
         show = Show(database_connection=_database_connection)
-        shows = show.retrieve_all_repeats_details(
-            inclusive=inclusive,
-            include_decimal_scores=_config["settings"]["use_decimal_scores"],
-        )
+        shows = show.retrieve_all_repeats_details(inclusive=inclusive)
+
         if shows:
             return {"shows": shows}
 
@@ -1343,6 +1325,7 @@ async def get_random_show():
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_random()
+
         if show_info:
             return show_info
 
@@ -1383,6 +1366,7 @@ async def get_random_show_date():
     try:
         show = Show(database_connection=_database_connection)
         _date = show.retrieve_random_date()
+
         if _date:
             return {"date": _date}
 
@@ -1423,6 +1407,7 @@ async def get_random_show_id():
     try:
         show = Show(database_connection=_database_connection)
         _id = show.retrieve_random_id()
+
         if _id:
             return {"id": _id}
 
@@ -1468,6 +1453,7 @@ async def get_random_show_by_year(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_random_by_year(year=year)
+
         if show_info:
             return show_info
 
@@ -1511,6 +1497,7 @@ async def get_shows_recent():
     try:
         show = Show(database_connection=_database_connection)
         shows = show.retrieve_recent()
+
         if shows:
             return {"shows": shows}
 
@@ -1548,6 +1535,7 @@ async def get_repeat_best_ofs():
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_all_repeat_best_ofs()
+
         if show_info:
             return {"shows": show_info}
 
@@ -1591,6 +1579,7 @@ async def get_shows_repeats(
     try:
         show = Show(database_connection=_database_connection)
         show_info = show.retrieve_all_repeats(inclusive=inclusive)
+
         if show_info:
             return {"shows": show_info}
 

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -5,13 +5,19 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """API routes for Application Version endpoints."""
 
+import mysql.connector
 from fastapi import APIRouter
+from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm import VERSION as WWDTM_VERSION
+from wwdtm import database_version
 
-from app.config import API_VERSION, APP_VERSION
+from app.config import API_VERSION, APP_VERSION, load_config
 from app.models.version import Version
 
 router = APIRouter(prefix=f"/v{API_VERSION}/version")
+_config = load_config()
+_database_config = _config["database"]
+_database_connection = mysql.connector.connect(**_database_config)
 
 
 @router.get(
@@ -23,8 +29,11 @@ router = APIRouter(prefix=f"/v{API_VERSION}/version")
 @router.head("", include_in_schema=False)
 async def get_version():
     """Retrieves API, Application and Wait Wait Stats Library Versions."""
+    _database_version = database_version(database_connection=_database_connection)
+
     return {
         "api": API_VERSION,
         "app": APP_VERSION,
+        "database": ".".join(str(segment) for segment in _database_version),
         "wwdtm": WWDTM_VERSION,
     }

--- a/app/routers/version.py
+++ b/app/routers/version.py
@@ -7,7 +7,6 @@
 
 import mysql.connector
 from fastapi import APIRouter
-from mysql.connector.errors import DatabaseError, ProgrammingError
 from wwdtm import VERSION as WWDTM_VERSION
 from wwdtm import database_version
 

--- a/config.json.dist
+++ b/config.json.dist
@@ -22,7 +22,6 @@
         "contact_url": "",
         "patreon_url": "",
         "github_sponsor_url": "",
-        "use_decimal_scores": false,
         "umami_analytics": {
             "_enabled": false,
             "url": "",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ jinja2~=3.1.6
 email-validator==2.3.0
 requests==2.33.1
 
-wwdtm==2.23.1
+wwdtm>=3.0.0a0, < 4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,16 @@
 ruff==0.14.14
+pydoclint==0.8.4
 pytest==9.0.3
 pytest-cov==7.0.0
 
-pydantic==2.12.5
-fastapi==0.128.0
-uvicorn[standard]==0.40.0
+aiofiles==25.1.0
+email-validator==2.3.0
+fastapi==0.136.3
 gunicorn==24.1.1
 httpx==0.28.1
-aiofiles==25.1.0
 jinja2~=3.1.6
-email-validator==2.3.0
+pydantic==2.13.4
 requests==2.33.1
+uvicorn[standard]==0.48.0
 
-wwdtm>=3.0.0a0, < 4.0
+wwdtm>=3.0.0, <3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ jinja2~=3.1.6
 email-validator==2.3.0
 requests==2.33.1
 
-wwdtm==2.23.1
+wwdtm>=3.0.0a0, < 4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pydantic==2.12.5
-fastapi==0.128.0
-uvicorn[standard]==0.40.0
+aiofiles==25.1.0
+email-validator==2.3.0
+fastapi==0.136.3
 gunicorn==24.1.1
 httpx==0.28.1
-aiofiles==25.1.0
 jinja2~=3.1.6
-email-validator==2.3.0
+pydantic==2.13.4
 requests==2.33.1
+uvicorn[standard]==0.48.0
 
-wwdtm>=3.0.0a0, < 4.0
+wwdtm>=3.0.0, <3.1

--- a/static/style.css
+++ b/static/style.css
@@ -3,6 +3,8 @@
  * Copyright 2018-2023 Linh Pham
  * Apache License 2.0 (https://github.com/questionlp/api.wwdt.me_v2/blob/main/LICENSE)
  */
+@import url(https://fonts.bunny.net/css?family=ibm-plex-sans:400,700);
+
 @media all {
     html {
         font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Wait Wait Don't Tell Me Stats API Landing Page</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 
     {% if umami_analytics -%}


### PR DESCRIPTION
## Application Changes

- The Stats API now requires panelist decimal score columns in the Wait Wait Stats Database
  - Removed the `settings.use_decimal_scores` configuration key references and logic
- Added `database` field to the `Version` model and to the output of the `/version` endpoint
- Replaced Google Fonts with Bunny Fonts as the web font provider for the required IBM Plex fonts

## Component Changes

- Upgraded FastAPI from 0.128.0 to 0.136.3
- Upgraded Pydantic from 2.12.5 to 2.13.4
- Upgraded uvicorn from 0.40.0 to 0.48.0
- Upgraded wwdtm from 2.23.1 to 3.0.0

## Development Changes

- Added pydoclint 0.8.4 for docstring linting